### PR TITLE
Save creation date in ISO 8601 UTC

### DIFF
--- a/packer/main.py
+++ b/packer/main.py
@@ -182,7 +182,7 @@ class CreateJobHandler(BaseHandler):
             job_parameters=job_parameters,
             status=Status.REGISTERED,
             user=self.current_user,
-            created_at=str(datetime.now())
+            created_at=datetime.utcnow().isoformat(sep='T', timespec='seconds') + 'Z'
         )
 
         try:


### PR DESCRIPTION
With Z at the end. e.g. 2018-11-22T15:57:10Z

Gb expects dates in UTC, not local time. 
The PR fixes an issue when gb shows that export has been made 1 hour before right after the export. 