### PR TITLE
Expect the same KEYCLOAK_SERVER_URL in all glowing-bear-docker components

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -19,7 +19,9 @@ services:
             - redis
         environment:
           TRANSMART_URL: 'http://localhost:8081'
-          KEYCLOAK_URL: 'http://localhost:8080/auth/realms/dev'
+          KEYCLOAK_SERVER_URL: 'http://localhost:8080'
+          KEYCLOAK_REALM: 'dev'
+          KEYCLOAK_CLIENT_ID: 'transmart'
           CLIENT_ORIGIN_URL: 'http://localhost:4200'
 
     worker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,10 @@ services:
             - redis
         environment:
           TRANSMART_URL: 'https://transmart-dev.thehyve.net'
-          KEYCLOAK_URL: 'https://keycloak-dwh-test.thehyve.net/auth/realms/transmart-dev'
+          KEYCLOAK_SERVER_URL: 'https://keycloak-dwh-test.thehyve.net'
+          KEYCLOAK_REALM: 'transmart-dev'
+          KEYCLOAK_CLIENT_ID: 'transmart-client'
           CLIENT_ORIGIN_URL: '*'
-          CLIENT_ID: 'transmart-client'
 
     worker:
         image: thehyve/transmart-packer

--- a/packer/config.py
+++ b/packer/config.py
@@ -7,8 +7,8 @@ tornado_config = dict(
 )
 
 keycloak_config = dict(
-    oidc_server_url=os.environ.get('KEYCLOAK_URL'),
-    client_id=os.environ.get('CLIENT_ID', 'transmart'),
+    oidc_server_url=os.environ.get('KEYCLOAK_SERVER_URL')+'/auth/realms/'+os.environ.get('KEYCLOAK_REALM'),
+    client_id=os.environ.get('KEYCLOAK_CLIENT_ID', 'transmart'),
 )
 
 transmart_config = dict(


### PR DESCRIPTION
Expect `https://keycloak-example.com` (without `/auth` and realm parts)