### PR TITLE
Add task user impersonation to prevent failing on high load

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,9 @@ Variable                        Description
 ==============================  =================
 ``TRANSMART_URL``               The URL of the TranSMART API server
 ``KEYCLOAK_SERVER_URL``         Keycloak server URL, e.g., ``https://keycloak-dwh-test.thehyve.net``
-``KEYCLOAK_REALM``              The Keycloak realm, e.g., ``transmart-dev``
+``KEYCLOAK_REALM``              The Keycloak realm (default: ``transmart``)
 ``KEYCLOAK_CLIENT_ID``          The Keycloak client ID (default: ``transmart-client``)
+``KEYCLOAK_OFFLINE_TOKEN``      The Keycloak offline token.
 ``REDIS_URL``                   Redis server URL (default: ``redis://localhost:6379``)
 ``DATA_DIR``                    Directory to write export data (default: ``/tmp/packer/``)
 ``LOG_CFG``                     Logging configuration (default: ``packer/logging.yaml``)
@@ -77,8 +78,28 @@ Variable                        Description
 An optional variable `VERIFY_CERT` can be used to specify the path of a certificate collection file (`.pem`)
 used to verify HTTP requests.
 
+`KEYCLOAK_OFFLINE_TOKEN` should be generated for a user that has the following `realm-management` roles:
 
-Alternatively, you could build and run the stack from code using ``docker-compose``.
+- ``offline_access`` - to be able to get the offline token.
+- ``impersonation`` - to support running tranSMART queries on behalf of task users.
+
+To get the token, run:
+
+.. code-block:: bash
+
+    curl \
+      -d 'client_id=KEYCLOAK_CLIENT_ID' \
+      -d 'username=OFFLINE_USERNAME' \
+      -d 'password=OFFLINE_USERNAME_PASSWORD' \
+      -d 'grant_type=password' \
+      -d 'scope=offline_access' \
+      'https://KEYCLOAK_SERVER_URL/auth/realms/KEYCLOAK_REALM/protocol/openid-connect/token'
+
+
+The value of the `refresh_token` field in the response is the offline token.
+
+
+To run the stack using ``docker-compose`` follow the commands below:
 
 .. code-block:: bash
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,10 +18,11 @@ services:
     links:
       - redis
     environment:
-      TRANSMART_URL: ${TRANSMART_URL:-https://transmart-dev.thehyve.net}
-      KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL:-https://keycloak-dwh-test.thehyve.net}
-      KEYCLOAK_REALM: ${KEYCLOAK_REALM:-transmart-dev}
+      TRANSMART_URL: ${TRANSMART_URL:?Please configure TRANSMART_URL}
+      KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL:?Please configure KEYCLOAK_SERVER_URL}
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM:?Please configure KEYCLOAK_REALM}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID:-transmart-client}
+      KEYCLOAK_OFFLINE_TOKEN: ${KEYCLOAK_OFFLINE_TOKEN:?Please configure KEYCLOAK_OFFLINE_TOKEN}
       CLIENT_ORIGIN_URL: '*'
     volumes:
       - transmart-packer-webapp-data:/app/tmp_data_dir
@@ -36,6 +37,10 @@ services:
       - redis
     environment:
       TRANSMART_URL: ${TRANSMART_URL:-https://transmart-dev.thehyve.net}
+      KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL:?Please configure KEYCLOAK_SERVER_URL}
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM:?Please configure KEYCLOAK_REALM}
+      KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID:-transmart-client}
+      KEYCLOAK_OFFLINE_TOKEN: ${KEYCLOAK_OFFLINE_TOKEN:?Please configure KEYCLOAK_OFFLINE_TOKEN}
     volumes:
       - transmart-packer-worker-data:/app/tmp_data_dir
       - ./ssl/certs.pem:/ssl/certs.pem

--- a/packer/auth.py
+++ b/packer/auth.py
@@ -1,0 +1,121 @@
+import functools
+import json
+import logging
+from typing import Mapping, Dict
+
+import jwt
+import requests
+from jwt.algorithms import RSAAlgorithm
+from tornado.log import app_log as log
+from tornado.web import HTTPError
+
+from .config import keycloak_config, http_config
+
+logger = logging.getLogger(__name__)
+
+
+def authorize(token: str) -> Mapping:
+    """
+    Validate the token to authorize the access
+    :param token: request token
+    :return: user's token
+    """
+    if token is None or len(token) == 0:
+        error_msg = 'No authorisation token found in the request'
+        logger.error(error_msg)
+        raise HTTPError(401, 'Unauthorized.')
+    decoded_token_header = jwt.get_unverified_header(token)
+    token_kid = decoded_token_header.get('kid')
+    algorithm, public_key = get_keycloak_public_key_and_algorithm(token_kid)
+    user_token = jwt.decode(token, public_key, algorithms=algorithm, audience=keycloak_config.get("client_id"))
+    return user_token
+
+
+@functools.lru_cache(maxsize=2)
+def get_keycloak_public_key_and_algorithm(token_kid):
+    """
+    Get Keycloak public key and token signing algorithm
+    :param token_kid: Token kid
+    :return: Algorithm and public_key pair
+    """
+    handle = f'{keycloak_config.get("oidc_server_url")}/protocol/openid-connect/certs'
+    log.info(f'Getting public key for the kid={token_kid} from the keycloak...')
+    r = requests.get(handle, verify=http_config.get('verify_cert'))
+    if not r.ok:
+        error = "Could not get certificates from Keycloak. " \
+                "Reason: [{}]: {}".format(r.status_code, r.text)
+        logger.error(error)
+        raise ValueError(error)
+    try:
+        json_response = r.json()
+    except Exception:
+        error = "Could not retrieve the public key. " \
+                "Got unexpected response: '{}'".format(r.text)
+        logging.error(error)
+        raise ValueError(error)
+    try:
+        matching_key = next((item for item in json_response.get('keys') if item['kid'] == token_kid), None)
+        if matching_key is None:
+            error = "No public key found for kid {}".format(token_kid)
+            logger.error(error)
+            raise ValueError(error)
+        matching_key_json = json.dumps(matching_key)
+        public_key = RSAAlgorithm.from_jwk(matching_key_json)
+    except Exception as e:
+        error = f'Invalid public key!. Reason: {e}'
+        logger.error(error)
+        raise ValueError(error)
+    logger.info(f'The public key for the kid={token_kid} has been fetched.')
+    return matching_key.get('alg'), public_key
+
+
+def get_impersonated_token_for_user(current_user: str) -> str:
+    """
+    Exchange offline token for (impersonated) current task user’s token
+    :param current_user: current task user
+    :return: task user's access token
+    """
+    offline_user_access_token = get_access_token_by_offline_token()
+    handle = f'{keycloak_config.get("oidc_server_url")}/protocol/openid-connect/token'
+    params = {'grant_type': 'urn:ietf:params:oauth:grant-type:token-exchange',
+              'requested_subject': current_user,
+              'client_id': f'{keycloak_config.get("client_id")}',
+              'subject_token': offline_user_access_token}
+    return get_access_token(handle, params)
+
+
+def get_access_token_by_offline_token() -> str:
+    """
+    Get access token based on offline token
+    :return: offline user's access token
+    """
+    handle = f'{keycloak_config.get("oidc_server_url")}/protocol/openid-connect/token'
+    params = {'grant_type': 'refresh_token',
+              'scope': 'offline_access',
+              'client_id': f'{keycloak_config.get("client_id")}',
+              'refresh_token': f'{keycloak_config.get("offline_token")}'}
+    return get_access_token(handle, params)
+
+
+def get_access_token(url: str, params: Dict) -> str:
+    """
+    Get access token from Keycloak
+    :param url: Keycloak server URL
+    :param params: Request body params
+    :return: access token
+    """
+    response = requests.post(url=url, data=params, verify=http_config.get('verify_cert'))
+    if not response.ok:
+        error = "Could not get a token from Keycloak. " \
+                "Reason: [{}]: {}".format(response.status_code, response.text)
+        logger.error(error)
+        raise ValueError(error)
+    try:
+        json_response = response.json()
+        return json_response['access_token']
+    except Exception:
+        error = "Could not retrieve the access token. " \
+                "Got unexpected response: '{}'".format(response.text)
+        logger.error(error)
+        raise ValueError(error)
+

--- a/packer/config.py
+++ b/packer/config.py
@@ -17,6 +17,7 @@ tornado_config = dict(
 keycloak_config = dict(
     oidc_server_url='{}/auth/realms/{}'.format(os.environ.get('KEYCLOAK_SERVER_URL'), os.environ.get('KEYCLOAK_REALM')),
     client_id=os.environ.get('KEYCLOAK_CLIENT_ID', 'transmart-client'),
+    offline_token=os.environ.get('KEYCLOAK_OFFLINE_TOKEN')
 )
 
 transmart_config = dict(


### PR DESCRIPTION
Problem: 
In glowing-bear use case packer uses transmart request tokento interact with transmart api. The token expires in configured amount of time. There is no possibility to renew the token from the packer at the moment, so the job fails sporadically.   

Solution:
Add a possibility to renew the token by packer using offline token and user impersonation. 

Related issue: [TMT-619](https://jira.thehyve.nl/browse/TMT-619)