### PR TITLE
Include radiology data in CSR export.

### DIFF
--- a/packer/table_transformations/csr_transformations.py
+++ b/packer/table_transformations/csr_transformations.py
@@ -50,14 +50,9 @@ def from_obs_json_to_export_csr_df(obs_json: Dict) -> DataFrame:
         else:
             # Merge sample and study data, creating a cross-product
             study_df['Study Id'] = study_df.index.get_level_values('Study Id')
-            df = sample_df.merge(study_df,
-                                 on='Subject Id',
-                                 how='outer',
-                                 right_index=True
-                                 )
+            df = sample_df.reset_index().merge(study_df, on='Subject Id', how='outer')
         # Create combined index with sample and study identifiers
-        id_columns = df.index.names + [column for column in ID_COLUMNS if column in set(df.columns)]
-        df.reset_index(inplace=True)
+        id_columns = [column for column in ID_COLUMNS if column in set(df.columns)]
         df.set_index(id_columns, inplace=True)
 
     df = df.rename(index=str, columns=concept_pat_to_name)

--- a/packer/table_transformations/utils.py
+++ b/packer/table_transformations/utils.py
@@ -16,3 +16,15 @@ def filter_rows(df: pd.DataFrame, filter_row_df: pd.DataFrame) -> pd.DataFrame:
     filter_df_common_indx = filter_row_df.reset_index().set_index(common_indx_names).index
     filtered_df = df[df_common_indx.isin(filter_df_common_indx)]
     return filtered_df
+
+
+def get_index_of_string_prefix(x: str, indexed_list: list) -> int:
+    """
+    :param x: a string, prefix of which is to be verified
+    :param indexed_list: list of string elements
+    :return: index of an element on the indexed_list that equals to the x prefix
+    """
+    for list_elem in indexed_list:
+        if x.startswith(list_elem + "."):
+            return indexed_list.index(list_elem)
+    return len(indexed_list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ transmart[full] == 0.2.6
 redis == 3.2.1
 celery == 4.3.0
 vine == 1.3.0
-tornado >= 6.0.4, < 6.1.0
+tornado >= 6.0.4, <= 6.1
 aioredis >= 1.3.1, < 1.4.0
 cryptography == 2.6.1
 pyjwt == 1.7.1
 requests == 2.22.0
-pandas >= 0.25.1, < 0.26.0
+pandas >= 1.1.4, <= 1.3.5
 numpy >= 1.17.5, < 1.18.0

--- a/tests/csr_observations.json
+++ b/tests/csr_observations.json
@@ -1,4167 +1,5410 @@
 {
-    "dimensionDeclarations": [
+  "dimensionDeclarations": [
+    {
+      "name": "Radiology",
+      "dimensionType": "subject",
+      "sortIndex": 5,
+      "valueType": "String",
+      "modifierCode": "Radiology"
+    },
+    {
+      "name": "study",
+      "dimensionType": "attribute",
+      "sortIndex": null,
+      "valueType": "Object",
+      "fields": [
         {
-            "name": "study",
-            "type": "Object",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "String"
-                }
-            ]
-        },
-        {
-            "name": "Study",
-            "type": "String"
-        },
-        {
-            "name": "Biomaterial",
-            "type": "String"
-        },
-        {
-            "name": "Biosource",
-            "type": "String"
-        },
-        {
-            "name": "concept",
-            "type": "Object",
-            "fields": [
-                {
-                    "name": "conceptPath",
-                    "type": "String"
-                },
-                {
-                    "name": "conceptCode",
-                    "type": "String"
-                },
-                {
-                    "name": "name",
-                    "type": "String"
-                }
-            ]
-        },
-        {
-            "name": "Diagnosis",
-            "type": "String"
-        },
-        {
-            "name": "patient",
-            "type": "Object",
-            "fields": [
-                {
-                    "name": "id",
-                    "type": "Int"
-                },
-                {
-                    "name": "trial",
-                    "type": "String"
-                },
-                {
-                    "name": "inTrialId",
-                    "type": "String"
-                },
-                {
-                    "name": "subjectIds",
-                    "type": "Object"
-                },
-                {
-                    "name": "birthDate",
-                    "type": "Timestamp"
-                },
-                {
-                    "name": "deathDate",
-                    "type": "Timestamp"
-                },
-                {
-                    "name": "age",
-                    "type": "Int"
-                },
-                {
-                    "name": "race",
-                    "type": "String"
-                },
-                {
-                    "name": "maritalStatus",
-                    "type": "String"
-                },
-                {
-                    "name": "religion",
-                    "type": "String"
-                },
-                {
-                    "name": "sexCd",
-                    "type": "String"
-                },
-                {
-                    "name": "sex",
-                    "type": "String"
-                }
-            ]
+          "name": "name",
+          "type": "String"
         }
-    ],
-    "sort": [
+      ]
+    },
+    {
+      "name": "Study",
+      "dimensionType": null,
+      "sortIndex": 6,
+      "valueType": "String",
+      "modifierCode": "Study"
+    },
+    {
+      "name": "start time",
+      "dimensionType": "attribute",
+      "sortIndex": null,
+      "valueType": "Timestamp",
+      "inline": true
+    },
+    {
+      "name": "Biomaterial",
+      "dimensionType": "subject",
+      "sortIndex": 4,
+      "valueType": "String",
+      "modifierCode": "Biomaterial"
+    },
+    {
+      "name": "concept",
+      "dimensionType": "attribute",
+      "sortIndex": null,
+      "valueType": "Object",
+      "fields": [
         {
-            "dimension": "concept",
-            "sortOrder": "asc"
+          "name": "conceptPath",
+          "type": "String"
         },
         {
-            "dimension": "provider",
-            "sortOrder": "asc"
+          "name": "conceptCode",
+          "type": "String"
         },
         {
-            "dimension": "patient",
-            "sortOrder": "asc"
-        },
-        {
-            "dimension": "visit",
-            "sortOrder": "asc"
-        },
-        {
-            "dimension": "start time",
-            "sortOrder": "asc"
+          "name": "name",
+          "type": "String"
         }
-    ],
-    "cells": [
+      ]
+    },
+    {
+      "name": "Biosource",
+      "dimensionType": "subject",
+      "sortIndex": 3,
+      "valueType": "String",
+      "modifierCode": "Biosource"
+    },
+    {
+      "name": "visit",
+      "dimensionType": "attribute",
+      "sortIndex": null,
+      "valueType": "Object",
+      "fields": [
         {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                0,
-                0,
-                0,
-                0,
-                0
-            ],
-            "stringValue": "9"
+          "name": "id",
+          "type": "Int"
         },
         {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                1,
-                0,
-                0,
-                0,
-                0
-            ],
-            "stringValue": "BM9"
+          "name": "patientId",
+          "type": "Int"
         },
         {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                2,
-                1,
-                0,
-                1,
-                1
-            ],
-            "stringValue": "BM6"
+          "name": "activeStatusCd",
+          "type": "String"
         },
         {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                1,
-                null,
-                0
-            ],
-            "stringValue": "yes"
+          "name": "startDate",
+          "type": "Timestamp"
         },
         {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                1,
-                null,
-                2
-            ],
-            "stringValue": "yes"
+          "name": "endDate",
+          "type": "Timestamp"
         },
         {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                1,
-                null,
-                3
-            ],
-            "stringValue": "yes"
+          "name": "inoutCd",
+          "type": "String"
         },
         {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                1,
-                null,
-                4
-            ],
-            "stringValue": "yes"
+          "name": "locationCd",
+          "type": "String"
         },
         {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                1,
-                null,
-                5
-            ],
-            "stringValue": "yes"
+          "name": "lengthOfStay",
+          "type": "Double"
         },
         {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                1,
-                null,
-                6
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                1,
-                null,
-                1
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                1,
-                null,
-                7
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                2,
-                null,
-                0
-            ],
-            "stringValue": "STD1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                2,
-                null,
-                2
-            ],
-            "stringValue": "STD1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                2,
-                null,
-                3
-            ],
-            "stringValue": "STD1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                2,
-                null,
-                4
-            ],
-            "stringValue": "STD1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                2,
-                null,
-                8
-            ],
-            "stringValue": "STD1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                2,
-                3,
-                2,
-                0
-            ],
-            "stringValue": "2017-03-12T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                0,
-                3,
-                0,
-                0
-            ],
-            "stringValue": "2017-06-10T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                3,
-                3,
-                3,
-                3
-            ],
-            "stringValue": "2017-04-01T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                4,
-                3,
-                null,
-                4
-            ],
-            "stringValue": "2017-05-14T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                5,
-                3,
-                4,
-                8
-            ],
-            "stringValue": "2017-06-21T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                6,
-                3,
-                5,
-                8
-            ],
-            "stringValue": "2017-07-22T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                7,
-                3,
-                4,
-                8
-            ],
-            "stringValue": "2016-08-11T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                8,
-                3,
-                6,
-                5
-            ],
-            "stringValue": "2017-07-10T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                9,
-                3,
-                6,
-                5
-            ],
-            "stringValue": "2017-05-10T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                10,
-                3,
-                7,
-                6
-            ],
-            "stringValue": "2017-08-21T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                1,
-                3,
-                1,
-                1
-            ],
-            "stringValue": "2017-03-10T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                11,
-                3,
-                8,
-                7
-            ],
-            "stringValue": "2017-04-30T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                3,
-                2,
-                4,
-                2,
-                0
-            ],
-            "stringValue": "2017-10-12T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                0,
-                0,
-                4,
-                0,
-                0
-            ],
-            "stringValue": "2017-12-12T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                1,
-                0,
-                4,
-                0,
-                0
-            ],
-            "stringValue": "2017-12-02T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                4,
-                3,
-                4,
-                3,
-                3
-            ],
-            "stringValue": "2017-11-22T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                5,
-                4,
-                4,
-                null,
-                4
-            ],
-            "stringValue": "2017-12-12T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                6,
-                5,
-                4,
-                4,
-                8
-            ],
-            "stringValue": "2017-10-12T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                7,
-                6,
-                4,
-                5,
-                8
-            ],
-            "stringValue": "2017-10-12T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                8,
-                7,
-                4,
-                4,
-                8
-            ],
-            "stringValue": "2017-11-22T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                9,
-                5,
-                4,
-                4,
-                8
-            ],
-            "stringValue": "2017-12-12T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                10,
-                8,
-                4,
-                6,
-                5
-            ],
-            "stringValue": "2017-11-22T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                11,
-                9,
-                4,
-                6,
-                5
-            ],
-            "stringValue": "2017-08-22T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                12,
-                8,
-                4,
-                6,
-                5
-            ],
-            "stringValue": "2017-07-12T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                2,
-                1,
-                4,
-                1,
-                1
-            ],
-            "stringValue": "2017-09-12T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                13,
-                1,
-                4,
-                1,
-                1
-            ],
-            "stringValue": "2017-11-22T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                14,
-                11,
-                4,
-                8,
-                7
-            ],
-            "stringValue": "2017-10-12T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                5,
-                null,
-                0
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                5,
-                null,
-                2
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                5,
-                null,
-                4
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                5,
-                null,
-                5
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                5,
-                null,
-                6
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                5,
-                null,
-                7
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                2,
-                6,
-                2,
-                0
-            ],
-            "stringValue": "Yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                5,
-                6,
-                4,
-                8
-            ],
-            "stringValue": "No"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                7,
-                6,
-                4,
-                8
-            ],
-            "stringValue": "Yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                11,
-                6,
-                8,
-                7
-            ],
-            "stringValue": "No"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                7,
-                null,
-                0
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                7,
-                null,
-                2
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                7,
-                null,
-                3
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                7,
-                null,
-                4
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                7,
-                null,
-                8
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                7,
-                null,
-                5
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                7,
-                null,
-                6
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                7,
-                null,
-                1
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                7,
-                null,
-                7
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                2,
-                0
-            ],
-            "stringValue": "liver"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                0,
-                0
-            ],
-            "stringValue": "liver"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                9,
-                2
-            ],
-            "stringValue": "kidney"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                10,
-                3
-            ],
-            "stringValue": "bone marrow"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                3,
-                3
-            ],
-            "stringValue": "liver"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                4,
-                8
-            ],
-            "stringValue": "kidney"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                5,
-                8
-            ],
-            "stringValue": "bone marrow"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                6,
-                5
-            ],
-            "stringValue": "bone marrow"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                7,
-                6
-            ],
-            "stringValue": "liver"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                11,
-                6
-            ],
-            "stringValue": "kidney"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                1,
-                1
-            ],
-            "stringValue": "liver"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                8,
-                8,
-                7
-            ],
-            "stringValue": "kidney"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                2,
-                0
-            ],
-            "stringValue": "neuroblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                0,
-                0
-            ],
-            "stringValue": "neuroblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                9,
-                2
-            ],
-            "stringValue": "nephroblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                10,
-                3
-            ],
-            "stringValue": "hepatoblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                3,
-                3
-            ],
-            "stringValue": "nephroblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                4,
-                8
-            ],
-            "stringValue": "nephroblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                5,
-                8
-            ],
-            "stringValue": "hepatoblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                6,
-                5
-            ],
-            "stringValue": "hepatoblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                7,
-                6
-            ],
-            "stringValue": "neuroblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                11,
-                6
-            ],
-            "stringValue": "neuroblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                1,
-                1
-            ],
-            "stringValue": "nephroblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                9,
-                8,
-                7
-            ],
-            "stringValue": "hepatoblastoma"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                2,
-                10,
-                2,
-                0
-            ],
-            "stringValue": "ST1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                0,
-                10,
-                0,
-                0
-            ],
-            "stringValue": "ST4"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                3,
-                10,
-                3,
-                3
-            ],
-            "stringValue": "ST2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                4,
-                10,
-                null,
-                4
-            ],
-            "stringValue": "ST1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                5,
-                10,
-                4,
-                8
-            ],
-            "stringValue": "ST2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                6,
-                10,
-                5,
-                8
-            ],
-            "stringValue": "ST3"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                7,
-                10,
-                4,
-                8
-            ],
-            "stringValue": "ST4"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                8,
-                10,
-                6,
-                5
-            ],
-            "stringValue": "ST2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                9,
-                10,
-                6,
-                5
-            ],
-            "stringValue": "ST3"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                10,
-                10,
-                7,
-                6
-            ],
-            "stringValue": "ST3"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                1,
-                10,
-                1,
-                1
-            ],
-            "stringValue": "ST2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                11,
-                10,
-                8,
-                7
-            ],
-            "stringValue": "ST3"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                11,
-                null,
-                0
-            ],
-            "stringValue": "1993-02-01T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                11,
-                null,
-                2
-            ],
-            "stringValue": "1992-03-02T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                11,
-                null,
-                3
-            ],
-            "stringValue": "1994-04-03T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                11,
-                null,
-                4
-            ],
-            "stringValue": "1993-05-04T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                11,
-                null,
-                8
-            ],
-            "stringValue": "1995-06-05T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                11,
-                null,
-                5
-            ],
-            "stringValue": "1993-07-06T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                11,
-                null,
-                6
-            ],
-            "stringValue": "1993-08-07T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                11,
-                null,
-                1
-            ],
-            "stringValue": "1997-09-08T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                11,
-                null,
-                7
-            ],
-            "stringValue": "1993-10-09T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                2,
-                12,
-                2,
-                0
-            ],
-            "stringValue": "medula"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                0,
-                12,
-                0,
-                0
-            ],
-            "stringValue": "cortex"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                3,
-                12,
-                3,
-                3
-            ],
-            "stringValue": "cortex"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                4,
-                12,
-                null,
-                4
-            ],
-            "stringValue": "cortex"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                5,
-                12,
-                4,
-                8
-            ],
-            "stringValue": "medula"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                6,
-                12,
-                5,
-                8
-            ],
-            "stringValue": "medula"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                7,
-                12,
-                4,
-                8
-            ],
-            "stringValue": "medula"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                8,
-                12,
-                6,
-                5
-            ],
-            "stringValue": "medula"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                9,
-                12,
-                6,
-                5
-            ],
-            "stringValue": "medula"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                10,
-                12,
-                7,
-                6
-            ],
-            "stringValue": "cortex"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                1,
-                12,
-                1,
-                1
-            ],
-            "stringValue": "cortex"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                11,
-                12,
-                8,
-                7
-            ],
-            "stringValue": "medula"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                13,
-                null,
-                0
-            ],
-            "stringValue": "STUDY1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                13,
-                null,
-                2
-            ],
-            "stringValue": "STUDY1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                13,
-                null,
-                3
-            ],
-            "stringValue": "STUDY1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                13,
-                null,
-                4
-            ],
-            "stringValue": "STUDY1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                13,
-                null,
-                8
-            ],
-            "stringValue": "STUDY1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                2,
-                0
-            ],
-            "stringValue": "IV"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                0,
-                0
-            ],
-            "stringValue": "III"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                9,
-                2
-            ],
-            "stringValue": "III"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                10,
-                3
-            ],
-            "stringValue": "IV"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                3,
-                3
-            ],
-            "stringValue": "II"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                4,
-                8
-            ],
-            "stringValue": "I"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                5,
-                8
-            ],
-            "stringValue": "I"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                6,
-                5
-            ],
-            "stringValue": "II"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                7,
-                6
-            ],
-            "stringValue": "III"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                11,
-                6
-            ],
-            "stringValue": "II"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                1,
-                1
-            ],
-            "stringValue": "IV"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                14,
-                8,
-                7
-            ],
-            "stringValue": "II"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                15,
-                null,
-                3
-            ],
-            "stringValue": "not applicable"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                2,
-                16,
-                2,
-                0
-            ],
-            "stringValue": "BS1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                0,
-                16,
-                0,
-                0
-            ],
-            "stringValue": "BS10"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                3,
-                2,
-                16,
-                2,
-                0
-            ],
-            "stringValue": "BS1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                0,
-                0,
-                16,
-                0,
-                0
-            ],
-            "stringValue": "BS10"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                1,
-                0,
-                16,
-                0,
-                0
-            ],
-            "stringValue": "BS10"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                3,
-                16,
-                3,
-                3
-            ],
-            "stringValue": "BS2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                4,
-                3,
-                16,
-                3,
-                3
-            ],
-            "stringValue": "BS2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                4,
-                16,
-                null,
-                4
-            ],
-            "stringValue": "BS3"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                5,
-                4,
-                16,
-                null,
-                4
-            ],
-            "stringValue": "BS3"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                6,
-                16,
-                5,
-                8
-            ],
-            "stringValue": "BS11"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                7,
-                16,
-                4,
-                8
-            ],
-            "stringValue": "B4"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                6,
-                5,
-                16,
-                4,
-                8
-            ],
-            "stringValue": "BS4"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                7,
-                6,
-                16,
-                5,
-                8
-            ],
-            "stringValue": "BS11"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                8,
-                7,
-                16,
-                4,
-                8
-            ],
-            "stringValue": "BS12"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                9,
-                5,
-                16,
-                4,
-                8
-            ],
-            "stringValue": "BS4"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                8,
-                16,
-                6,
-                5
-            ],
-            "stringValue": "BS5"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                9,
-                16,
-                6,
-                5
-            ],
-            "stringValue": "BS9"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                10,
-                8,
-                16,
-                6,
-                5
-            ],
-            "stringValue": "BS5"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                11,
-                9,
-                16,
-                6,
-                5
-            ],
-            "stringValue": "BS9"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                12,
-                8,
-                16,
-                6,
-                5
-            ],
-            "stringValue": "BS5"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                10,
-                16,
-                7,
-                6
-            ],
-            "stringValue": "BS6"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                1,
-                16,
-                1,
-                1
-            ],
-            "stringValue": "BS7"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                2,
-                1,
-                16,
-                1,
-                1
-            ],
-            "stringValue": "BS7"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                13,
-                1,
-                16,
-                1,
-                1
-            ],
-            "stringValue": "BS7"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                11,
-                16,
-                8,
-                7
-            ],
-            "stringValue": "BS8"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                14,
-                11,
-                16,
-                8,
-                7
-            ],
-            "stringValue": "BS8"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                2,
-                17,
-                2,
-                0
-            ],
-            "numericValue": 5
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                0,
-                17,
-                0,
-                0
-            ],
-            "numericValue": 3
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                3,
-                17,
-                3,
-                3
-            ],
-            "numericValue": 3
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                4,
-                17,
-                null,
-                4
-            ],
-            "numericValue": 2
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                5,
-                17,
-                4,
-                8
-            ],
-            "numericValue": 1
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                6,
-                17,
-                5,
-                8
-            ],
-            "numericValue": 5
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                7,
-                17,
-                4,
-                8
-            ],
-            "numericValue": 1
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                8,
-                17,
-                6,
-                5
-            ],
-            "numericValue": 4
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                9,
-                17,
-                6,
-                5
-            ],
-            "numericValue": 2
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                10,
-                17,
-                7,
-                6
-            ],
-            "numericValue": 3
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                1,
-                17,
-                1,
-                1
-            ],
-            "numericValue": 1
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                11,
-                17,
-                8,
-                7
-            ],
-            "numericValue": 1
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                2,
-                0
-            ],
-            "stringValue": "2016-05-01T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                0,
-                0
-            ],
-            "stringValue": "2016-08-10T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                9,
-                2
-            ],
-            "stringValue": "2016-07-02T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                10,
-                3
-            ],
-            "stringValue": "2016-11-03T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                3,
-                3
-            ],
-            "stringValue": "2016-03-11T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                4,
-                8
-            ],
-            "stringValue": "2016-09-05T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                5,
-                8
-            ],
-            "stringValue": "2016-05-01T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                6,
-                5
-            ],
-            "stringValue": "2016-12-06T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                7,
-                6
-            ],
-            "stringValue": "2017-02-01T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                11,
-                6
-            ],
-            "stringValue": "2016-07-22T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                1,
-                1
-            ],
-            "stringValue": "2017-04-02T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                18,
-                8,
-                7
-            ],
-            "stringValue": "2016-05-09T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                2,
-                0
-            ],
-            "stringValue": "Center 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                0,
-                0
-            ],
-            "stringValue": "Center 2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                9,
-                2
-            ],
-            "stringValue": "Center 2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                10,
-                3
-            ],
-            "stringValue": "Center 3"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                3,
-                3
-            ],
-            "stringValue": "Center 3"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                4,
-                8
-            ],
-            "stringValue": "Center 2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                5,
-                8
-            ],
-            "stringValue": "Center 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                6,
-                5
-            ],
-            "stringValue": "Center 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                7,
-                6
-            ],
-            "stringValue": "Center 2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                11,
-                6
-            ],
-            "stringValue": "Center 2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                1,
-                1
-            ],
-            "stringValue": "Center 3"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                19,
-                8,
-                7
-            ],
-            "stringValue": "Center 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                20,
-                null,
-                0
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                20,
-                null,
-                2
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                20,
-                null,
-                3
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                20,
-                null,
-                4
-            ],
-            "stringValue": "no"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                20,
-                null,
-                8
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                20,
-                null,
-                5
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                20,
-                null,
-                6
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                20,
-                null,
-                1
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                20,
-                null,
-                7
-            ],
-            "stringValue": "yes"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                2,
-                null,
-                8
-            ],
-            "stringValue": "STD2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                2,
-                null,
-                5
-            ],
-            "stringValue": "STD2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                2,
-                null,
-                6
-            ],
-            "stringValue": "STD2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                2,
-                null,
-                1
-            ],
-            "stringValue": "STD2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                2,
-                null,
-                7
-            ],
-            "stringValue": "STD2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                22,
-                null,
-                0
-            ],
-            "numericValue": 1
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                22,
-                null,
-                2
-            ],
-            "numericValue": 2
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                22,
-                null,
-                3
-            ],
-            "numericValue": 3
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                22,
-                null,
-                4
-            ],
-            "numericValue": 4
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                22,
-                null,
-                8
-            ],
-            "numericValue": 5
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                2,
-                0
-            ],
-            "stringValue": "chemo"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                0,
-                0
-            ],
-            "stringValue": "chemo"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                9,
-                2
-            ],
-            "stringValue": "surgery"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                10,
-                3
-            ],
-            "stringValue": "Protocol 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                3,
-                3
-            ],
-            "stringValue": "Protocol 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                4,
-                8
-            ],
-            "stringValue": "chemo"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                5,
-                8
-            ],
-            "stringValue": "surgery"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                6,
-                5
-            ],
-            "stringValue": "chemo"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                7,
-                6
-            ],
-            "stringValue": "surgery"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                11,
-                6
-            ],
-            "stringValue": "surgery"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                1,
-                1
-            ],
-            "stringValue": "chemo"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                23,
-                8,
-                7
-            ],
-            "stringValue": "surgery"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                24,
-                null,
-                0
-            ],
-            "stringValue": "Human"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                24,
-                null,
-                2
-            ],
-            "stringValue": "Human"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                24,
-                null,
-                3
-            ],
-            "stringValue": "Human"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                24,
-                null,
-                4
-            ],
-            "stringValue": "Human"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                24,
-                null,
-                8
-            ],
-            "stringValue": "Human"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                24,
-                null,
-                5
-            ],
-            "stringValue": "Human"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                24,
-                null,
-                6
-            ],
-            "stringValue": "Human"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                24,
-                null,
-                1
-            ],
-            "stringValue": "Human"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                24,
-                null,
-                7
-            ],
-            "stringValue": "Human"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                3,
-                2,
-                25,
-                2,
-                0
-            ],
-            "stringValue": "RNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                0,
-                0,
-                25,
-                0,
-                0
-            ],
-            "stringValue": "RNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                1,
-                0,
-                25,
-                0,
-                0
-            ],
-            "stringValue": "DNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                4,
-                3,
-                25,
-                3,
-                3
-            ],
-            "stringValue": "DNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                5,
-                4,
-                25,
-                null,
-                4
-            ],
-            "stringValue": "RNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                6,
-                5,
-                25,
-                4,
-                8
-            ],
-            "stringValue": "DNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                7,
-                6,
-                25,
-                5,
-                8
-            ],
-            "stringValue": "DNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                8,
-                7,
-                25,
-                4,
-                8
-            ],
-            "stringValue": "RNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                9,
-                5,
-                25,
-                4,
-                8
-            ],
-            "stringValue": "DNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                10,
-                8,
-                25,
-                6,
-                5
-            ],
-            "stringValue": "RNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                11,
-                9,
-                25,
-                6,
-                5
-            ],
-            "stringValue": "DNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                12,
-                8,
-                25,
-                6,
-                5
-            ],
-            "stringValue": "RNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                2,
-                1,
-                25,
-                1,
-                1
-            ],
-            "stringValue": "DNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                13,
-                1,
-                25,
-                1,
-                1
-            ],
-            "stringValue": "DNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                14,
-                11,
-                25,
-                8,
-                7
-            ],
-            "stringValue": "RNA"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                26,
-                null,
-                5
-            ],
-            "stringValue": "2017-10-14T00:00:00Z"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                27,
-                null,
-                0
-            ],
-            "stringValue": "f"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                27,
-                null,
-                2
-            ],
-            "stringValue": "m"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                27,
-                null,
-                3
-            ],
-            "stringValue": "f"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                27,
-                null,
-                4
-            ],
-            "stringValue": "m"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                27,
-                null,
-                8
-            ],
-            "stringValue": "f"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                27,
-                null,
-                5
-            ],
-            "stringValue": "m"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                27,
-                null,
-                6
-            ],
-            "stringValue": "f"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                27,
-                null,
-                1
-            ],
-            "stringValue": "m"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                null,
-                null,
-                null,
-                27,
-                null,
-                7
-            ],
-            "stringValue": "f"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                28,
-                null,
-                8
-            ],
-            "stringValue": "Study 2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                28,
-                null,
-                5
-            ],
-            "stringValue": "Study 2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                28,
-                null,
-                6
-            ],
-            "stringValue": "Study 2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                28,
-                null,
-                1
-            ],
-            "stringValue": "Study 2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                28,
-                null,
-                7
-            ],
-            "stringValue": "Study 2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                22,
-                null,
-                8
-            ],
-            "numericValue": 6
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                22,
-                null,
-                5
-            ],
-            "numericValue": 7
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                22,
-                null,
-                6
-            ],
-            "numericValue": 8
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                22,
-                null,
-                1
-            ],
-            "numericValue": 9
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                22,
-                null,
-                7
-            ],
-            "numericValue": 10
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                28,
-                null,
-                0
-            ],
-            "stringValue": "Study 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                28,
-                null,
-                2
-            ],
-            "stringValue": "Study 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                28,
-                null,
-                3
-            ],
-            "stringValue": "Study 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                28,
-                null,
-                4
-            ],
-            "stringValue": "Study 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                0,
-                null,
-                null,
-                28,
-                null,
-                8
-            ],
-            "stringValue": "Study 1"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                13,
-                null,
-                8
-            ],
-            "stringValue": "STUDY2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                13,
-                null,
-                5
-            ],
-            "stringValue": "STUDY2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                13,
-                null,
-                6
-            ],
-            "stringValue": "STUDY2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                13,
-                null,
-                1
-            ],
-            "stringValue": "STUDY2"
-        },
-        {
-            "inlineDimensions": [],
-            "dimensionIndexes": [
-                0,
-                1,
-                null,
-                null,
-                13,
-                null,
-                7
-            ],
-            "stringValue": "STUDY2"
+          "name": "encounterIds",
+          "type": "Object"
         }
-    ],
-    "dimensionElements": {
-        "study": [
-            {
-                "name": "CSR"
-            }
-        ],
-        "Study": [
-            "STUDY1",
-            "STUDY2"
-        ],
-        "Biomaterial": [
-            "BM9",
-            "BM15",
-            "BM6",
-            "BM1",
-            "BM2",
-            "BM3",
-            "BM4",
-            "BM10",
-            "BM11",
-            "BM12",
-            "BM5",
-            "BM8",
-            "BM13",
-            "BM14",
-            "BM7"
-        ],
-        "Biosource": [
-            "BS10",
-            "BS7",
-            "BS1",
-            "BS2",
-            "BS3",
-            "BS4",
-            "BS11",
-            "BS12",
-            "BS5",
-            "BS9",
-            "BS6",
-            "BS8"
-        ],
-        "concept": [
-            {
-                "conceptPath": "\\Public Studies\\CSR\\04. Biomaterial information\\01. Biomaterial parent\\",
-                "conceptCode": "08e58306d0b4cf7e9b10dfe47135ef607d2bae3a",
-                "name": "01. Biomaterial parent"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\01. Patient information\\Informed consent\\04. Informed consent material\\",
-                "conceptCode": "0e87b77f99a0e9d444cf4729e88301231334630d",
-                "name": "04. Informed consent material"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\05. Study information\\02. Study acronym\\",
-                "conceptCode": "1cbd83e436976dee45dd5c446290b2cb508b801e",
-                "name": "02. Study acronym"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\03. Biosource information\\02. Date of biosource\\",
-                "conceptCode": "1ce3fc1098b2b8179e5b486b8349a5c08f807898",
-                "name": "02. Date of biosource"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\04. Biomaterial information\\02. Date of biomaterial\\",
-                "conceptCode": "1d92eaf563dcb89a4beca0698e983acf9b7c37a6",
-                "name": "02. Date of biomaterial"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\01. Patient information\\Informed consent\\05. Informed consent data\\",
-                "conceptCode": "246e7915066ee4a150322518b213181a7f3903d9",
-                "name": "05. Informed consent data"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\03. Biosource information\\06. Biosource dedicated for specific study\\",
-                "conceptCode": "309c81ae7e5f3fdcb3d32721460fb1796d4b24c3",
-                "name": "06. Biosource dedicated for specific study"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\01. Patient information\\Informed consent\\07. Report heriditary susceptibility\\",
-                "conceptCode": "480736dfd7cc2d85ec65223382b7c480b32f455c",
-                "name": "07. Report heriditary susceptibility"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\02. Diagnosis information\\03. Topography\\",
-                "conceptCode": "4f33eeb399622afda11f16c40a3e87dea82d6414",
-                "name": "03. Topography"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\02. Diagnosis information\\02. Tumor type\\",
-                "conceptCode": "4fc4afd045e321c824da01fae5c679cb34d71cac",
-                "name": "02. Tumor type"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\03. Biosource information\\04. Disease status\\",
-                "conceptCode": "584786ca0ff21ee8ceb22dc1e0d7d6ca7b2a90e3",
-                "name": "04. Disease status"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\01. Patient information\\01. Date of birth\\",
-                "conceptCode": "60da92e9c0229b8ce64785ce3060f2ac7a2ce8ac",
-                "name": "01. Date of birth"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\03. Biosource information\\03. Tissue\\",
-                "conceptCode": "640e439053c924ca78f5ec339e4f6fe26bd4073d",
-                "name": "03. Tissue"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\05. Study information\\01. Study ID\\",
-                "conceptCode": "6b74b1eda880cca4473e2793e13e88869c0a03a5",
-                "name": "01. Study ID"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\02. Diagnosis information\\04. Tumor stage\\",
-                "conceptCode": "7043ff91b2bd050feca89996be82eb1421a3372b",
-                "name": "04. Tumor stage"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\01. Patient information\\Informed consent\\06. Informed concent linking external database\\",
-                "conceptCode": "7816a9fbf89154bdbfadda6daded4b6c58dd37b3",
-                "name": "06. Informed concent linking external database"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\03. Biosource information\\01. Biosource parent\\",
-                "conceptCode": "82fe43990271eabe4266c0392e99327f7b68d9a8",
-                "name": "01. Biosource parent"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\03. Biosource information\\05. Tumor percentage\\",
-                "conceptCode": "83faa63b282f9ff2e97312309b3b18760a6db97b",
-                "name": "05. Tumor percentage"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\02. Diagnosis information\\01. Date of diagnosis\\",
-                "conceptCode": "9a35d3ffc12c75bbd93a8804e27d31ea1ee20c93",
-                "name": "01. Date of diagnosis"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\02. Diagnosis information\\05. Center of treatment\\",
-                "conceptCode": "a7cfe8e9c9d0ee7d282ee4bc579d9ea2d2f5f167",
-                "name": "05. Center of treatment"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\01. Patient information\\Informed consent\\01. Informed consent type\\",
-                "conceptCode": "b64e4f7183e7b75a6faedb430285e326c5a30fde",
-                "name": "01. Informed consent type"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\05. Study information\\02. Study acronym\\",
-                "conceptCode": "bb02b2fe41e213d2f2511228236e63c8144c2bd9",
-                "name": "02. Study acronym"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\05. Study information\\04. Individual Study ID\\",
-                "conceptCode": "c18ba4a966d996090e78993dc087b24dfaeea87a",
-                "name": "04. Individual Study ID"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\02. Diagnosis information\\Treatment\\",
-                "conceptCode": "c3bb4810113fc3daa877a2109c1a9c1358955021",
-                "name": "Treatment"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\01. Patient information\\Taxonomy\\",
-                "conceptCode": "debae43031f4a461b0e7a7fa0a0d89c793573df6",
-                "name": "Taxonomy"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\04. Biomaterial information\\03. Biomaterial type\\",
-                "conceptCode": "e0e1f2c1393ba80effa972e6f395566104fcce8e",
-                "name": "03. Biomaterial type"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\01. Patient information\\Informed consent\\03. Date informed consent withdrawn\\",
-                "conceptCode": "e1ee31813ba7572cfd8ac3a36ec5a22a3d22512e",
-                "name": "03. Date informed consent withdrawn"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\01. Patient information\\02. Gender\\",
-                "conceptCode": "e24277e1af6ded3d1a0b231f32e7723c566d5e67",
-                "name": "02. Gender"
-            },
-            {
-                "conceptPath": "\\Public Studies\\CSR\\05. Study information\\03. Study title\\",
-                "conceptCode": "e2823a4ea40466a199a724b967a1cd8f9f28b533",
-                "name": "03. Study title"
-            }
-        ],
-        "Diagnosis": [
-            "D10",
-            "D8",
-            "D1",
-            "D11",
-            "D5",
-            "D12",
-            "D6",
-            "D7",
-            "D9",
-            "D2",
-            "D3",
-            "D13"
-        ],
-        "patient": [
-            {
-                "id": 101,
-                "trial": null,
-                "inTrialId": null,
-                "subjectIds": {
-                    "SUBJ_ID": "P1"
-                },
-                "birthDate": null,
-                "deathDate": null,
-                "age": null,
-                "race": null,
-                "maritalStatus": null,
-                "religion": null,
-                "sexCd": null,
-                "sex": "unknown"
-            },
-            {
-                "id": 108,
-                "trial": null,
-                "inTrialId": null,
-                "subjectIds": {
-                    "SUBJ_ID": "P8"
-                },
-                "birthDate": null,
-                "deathDate": null,
-                "age": null,
-                "race": null,
-                "maritalStatus": null,
-                "religion": null,
-                "sexCd": null,
-                "sex": "unknown"
-            },
-            {
-                "id": 102,
-                "trial": null,
-                "inTrialId": null,
-                "subjectIds": {
-                    "SUBJ_ID": "P2"
-                },
-                "birthDate": null,
-                "deathDate": null,
-                "age": null,
-                "race": null,
-                "maritalStatus": null,
-                "religion": null,
-                "sexCd": null,
-                "sex": "unknown"
-            },
-            {
-                "id": 103,
-                "trial": null,
-                "inTrialId": null,
-                "subjectIds": {
-                    "SUBJ_ID": "P3"
-                },
-                "birthDate": null,
-                "deathDate": null,
-                "age": null,
-                "race": null,
-                "maritalStatus": null,
-                "religion": null,
-                "sexCd": null,
-                "sex": "unknown"
-            },
-            {
-                "id": 104,
-                "trial": null,
-                "inTrialId": null,
-                "subjectIds": {
-                    "SUBJ_ID": "P4"
-                },
-                "birthDate": null,
-                "deathDate": null,
-                "age": null,
-                "race": null,
-                "maritalStatus": null,
-                "religion": null,
-                "sexCd": null,
-                "sex": "unknown"
-            },
-            {
-                "id": 106,
-                "trial": null,
-                "inTrialId": null,
-                "subjectIds": {
-                    "SUBJ_ID": "P6"
-                },
-                "birthDate": null,
-                "deathDate": null,
-                "age": null,
-                "race": null,
-                "maritalStatus": null,
-                "religion": null,
-                "sexCd": null,
-                "sex": "unknown"
-            },
-            {
-                "id": 107,
-                "trial": null,
-                "inTrialId": null,
-                "subjectIds": {
-                    "SUBJ_ID": "P7"
-                },
-                "birthDate": null,
-                "deathDate": null,
-                "age": null,
-                "race": null,
-                "maritalStatus": null,
-                "religion": null,
-                "sexCd": null,
-                "sex": "unknown"
-            },
-            {
-                "id": 109,
-                "trial": null,
-                "inTrialId": null,
-                "subjectIds": {
-                    "SUBJ_ID": "P9"
-                },
-                "birthDate": null,
-                "deathDate": null,
-                "age": null,
-                "race": null,
-                "maritalStatus": null,
-                "religion": null,
-                "sexCd": null,
-                "sex": "unknown"
-            },
-            {
-                "id": 105,
-                "trial": null,
-                "inTrialId": null,
-                "subjectIds": {
-                    "SUBJ_ID": "P5"
-                },
-                "birthDate": null,
-                "deathDate": null,
-                "age": null,
-                "race": null,
-                "maritalStatus": null,
-                "religion": null,
-                "sexCd": null,
-                "sex": "unknown"
-            }
-        ]
+      ]
+    },
+    {
+      "name": "Diagnosis",
+      "dimensionType": "subject",
+      "sortIndex": 2,
+      "valueType": "String",
+      "modifierCode": "Diagnosis"
+    },
+    {
+      "name": "patient",
+      "dimensionType": "subject",
+      "sortIndex": null,
+      "valueType": "Object",
+      "fields": [
+        {
+          "name": "id",
+          "type": "Int"
+        },
+        {
+          "name": "trial",
+          "type": "String"
+        },
+        {
+          "name": "inTrialId",
+          "type": "String"
+        },
+        {
+          "name": "subjectIds",
+          "type": "Object"
+        },
+        {
+          "name": "birthDate",
+          "type": "Timestamp"
+        },
+        {
+          "name": "deathDate",
+          "type": "Timestamp"
+        },
+        {
+          "name": "age",
+          "type": "Int"
+        },
+        {
+          "name": "race",
+          "type": "String"
+        },
+        {
+          "name": "maritalStatus",
+          "type": "String"
+        },
+        {
+          "name": "religion",
+          "type": "String"
+        },
+        {
+          "name": "sexCd",
+          "type": "String"
+        },
+        {
+          "name": "sex",
+          "type": "String"
+        }
+      ]
     }
+  ],
+  "sort": [
+    {
+      "dimension": "concept",
+      "sortOrder": "asc"
+    },
+    {
+      "dimension": "provider",
+      "sortOrder": "asc"
+    },
+    {
+      "dimension": "patient",
+      "sortOrder": "asc"
+    },
+    {
+      "dimension": "visit",
+      "sortOrder": "asc"
+    },
+    {
+      "dimension": "start time",
+      "sortOrder": "asc"
+    }
+  ],
+  "cells": [
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        0,
+        0,
+        0,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "2017-11-22T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        1,
+        0,
+        1,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "2017-12-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        2,
+        0,
+        2,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "2017-11-22T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        3,
+        0,
+        3,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "2017-08-22T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        4,
+        0,
+        2,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "2017-07-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        5,
+        0,
+        4,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "2017-10-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        6,
+        0,
+        5,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "2017-12-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        7,
+        0,
+        5,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "2017-12-02T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        8,
+        0,
+        6,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "2017-10-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        9,
+        0,
+        7,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "2017-10-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        10,
+        0,
+        8,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "2017-11-22T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        11,
+        0,
+        6,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "2017-12-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        12,
+        0,
+        9,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "2017-09-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        13,
+        0,
+        9,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "2017-11-22T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        14,
+        0,
+        10,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "2017-10-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        6,
+        1,
+        5,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "9"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        7,
+        1,
+        5,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "BM9"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        0,
+        2,
+        0,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "DNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        1,
+        2,
+        1,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "RNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        2,
+        2,
+        2,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "RNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        3,
+        2,
+        3,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "DNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        4,
+        2,
+        2,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "RNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        5,
+        2,
+        4,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "RNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        6,
+        2,
+        5,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "RNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        7,
+        2,
+        5,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "DNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        8,
+        2,
+        6,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "DNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        9,
+        2,
+        7,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "DNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        10,
+        2,
+        8,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "RNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        11,
+        2,
+        6,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "DNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        12,
+        2,
+        9,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "DNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        13,
+        2,
+        9,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "DNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        14,
+        2,
+        10,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "RNA"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        0,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "2017-04-01T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        1,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "2017-05-14T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        2,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "2017-07-10T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        3,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "2017-05-10T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        4,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "2017-03-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        5,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "2017-06-10T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        6,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "2017-06-21T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        7,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "2017-07-22T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        8,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "2016-08-11T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        11,
+        null,
+        8,
+        7
+      ],
+      "stringValue": "2017-08-21T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        9,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "2017-03-10T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        3,
+        10,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "2017-04-30T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        4,
+        4,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "Yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        4,
+        6,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "No"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        4,
+        8,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "Yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        4,
+        10,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "No"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        0,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "ST2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        1,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "ST1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        2,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "ST2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        3,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "ST3"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        4,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "ST1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        5,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "ST4"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        6,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "ST2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        7,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "ST3"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        8,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "ST4"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        11,
+        null,
+        8,
+        7
+      ],
+      "stringValue": "ST3"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        9,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "ST2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        5,
+        10,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "ST3"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        6,
+        8,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "B4"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        0,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "cortex"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        1,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "cortex"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        2,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "medula"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        3,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "medula"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        4,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "medula"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        5,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "cortex"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        6,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "medula"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        7,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "medula"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        8,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "medula"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        11,
+        null,
+        8,
+        7
+      ],
+      "stringValue": "cortex"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        9,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "cortex"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        7,
+        10,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "medula"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        0,
+        null,
+        0,
+        0
+      ],
+      "numericValue": 3.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        1,
+        null,
+        null,
+        1
+      ],
+      "numericValue": 2.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        2,
+        null,
+        1,
+        2
+      ],
+      "numericValue": 4.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        3,
+        null,
+        1,
+        2
+      ],
+      "numericValue": 2.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        4,
+        null,
+        2,
+        3
+      ],
+      "numericValue": 5.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        5,
+        null,
+        3,
+        3
+      ],
+      "numericValue": 3.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        6,
+        null,
+        4,
+        4
+      ],
+      "numericValue": 1.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        7,
+        null,
+        5,
+        4
+      ],
+      "numericValue": 5.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        8,
+        null,
+        4,
+        4
+      ],
+      "numericValue": 1.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        11,
+        null,
+        8,
+        7
+      ],
+      "numericValue": 3.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        9,
+        null,
+        6,
+        5
+      ],
+      "numericValue": 1.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        8,
+        10,
+        null,
+        7,
+        6
+      ],
+      "numericValue": 1.0
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "Center 2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        10,
+        0
+      ],
+      "stringValue": "Center 3"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "Center 3"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "Center 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "Center 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "Center 2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "Center 2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "Center 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        8,
+        7
+      ],
+      "stringValue": "Center 2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        11,
+        7
+      ],
+      "stringValue": "Center 2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "Center 3"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        9,
+        null,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "Center 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "2016-07-02T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        10,
+        0
+      ],
+      "stringValue": "2016-11-03T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "2016-03-11T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "2016-12-06T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "2016-05-01T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "2016-08-10T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "2016-09-05T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "2016-05-01T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        8,
+        7
+      ],
+      "stringValue": "2017-02-01T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        11,
+        7
+      ],
+      "stringValue": "2016-07-22T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "2017-04-02T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        10,
+        null,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "2016-05-09T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "kidney"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        10,
+        0
+      ],
+      "stringValue": "bone marrow"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "liver"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "bone marrow"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "liver"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "liver"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "kidney"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "bone marrow"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        8,
+        7
+      ],
+      "stringValue": "liver"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        11,
+        7
+      ],
+      "stringValue": "kidney"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "liver"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        11,
+        null,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "kidney"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "surgery"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        10,
+        0
+      ],
+      "stringValue": "Protocol 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "Protocol 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "chemo"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "chemo"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "chemo"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "chemo"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "surgery"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        8,
+        7
+      ],
+      "stringValue": "surgery"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        11,
+        7
+      ],
+      "stringValue": "surgery"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "chemo"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        12,
+        null,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "surgery"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "III"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        10,
+        0
+      ],
+      "stringValue": "IV"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "II"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "II"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "IV"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "III"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "I"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "I"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        8,
+        7
+      ],
+      "stringValue": "III"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        11,
+        7
+      ],
+      "stringValue": "II"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "IV"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        13,
+        null,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "II"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "nephroblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        10,
+        0
+      ],
+      "stringValue": "hepatoblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        0,
+        0
+      ],
+      "stringValue": "nephroblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        1,
+        2
+      ],
+      "stringValue": "hepatoblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "neuroblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        3,
+        3
+      ],
+      "stringValue": "neuroblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        4,
+        4
+      ],
+      "stringValue": "nephroblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        5,
+        4
+      ],
+      "stringValue": "hepatoblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        8,
+        7
+      ],
+      "stringValue": "neuroblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        11,
+        7
+      ],
+      "stringValue": "neuroblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        6,
+        5
+      ],
+      "stringValue": "nephroblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        14,
+        null,
+        null,
+        7,
+        6
+      ],
+      "stringValue": "hepatoblastoma"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        15,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "1992-03-02T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        15,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "1994-04-03T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        15,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "1993-05-04T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        15,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "1993-07-06T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        15,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "1993-02-01T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        15,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "1995-06-05T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        15,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "1993-08-07T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        15,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "1997-09-08T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        15,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "1993-10-09T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        16,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "male"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        16,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "female"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        16,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "male"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        16,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "male"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        16,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "female"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        16,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "female"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        16,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "female"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        16,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "male"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        16,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "female"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        17,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "2017-04-10T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        17,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "2017-05-11T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        17,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "2017-06-13T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        17,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "2017-08-20T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        17,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "2017-03-01T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        17,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "2017-07-05T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        17,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "2017-09-12T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        17,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "2017-10-14T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        17,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "2017-11-16T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        18,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        18,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        18,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "no"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        18,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        18,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        18,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        18,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        18,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        18,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        19,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "2018-06-02T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        19,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "2018-06-03T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        19,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "2018-06-04T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        19,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "2017-10-14T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        20,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        20,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        20,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        20,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        20,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        20,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        20,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        20,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        20,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "yes"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        21,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        21,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "3"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        21,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "4"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        21,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        21,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        21,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "5"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        21,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        21,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "3"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        21,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "4"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        21,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "5"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        22,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "Human"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        22,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "Human"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        22,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "Human"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        22,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "Human"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        22,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "Human"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        22,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "Human"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        22,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "Human"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        22,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "Human"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        null,
+        null,
+        22,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "Human"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        0,
+        0,
+        null,
+        null,
+        23,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "torso"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        1,
+        0,
+        null,
+        null,
+        23,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "legs"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        2,
+        0,
+        null,
+        null,
+        23,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "torso"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        0,
+        0,
+        null,
+        null,
+        24,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "D2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        2,
+        0,
+        null,
+        null,
+        24,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "D1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        0,
+        0,
+        null,
+        null,
+        25,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "2016-07-02T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        1,
+        0,
+        null,
+        null,
+        25,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "2016-11-03T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        2,
+        0,
+        null,
+        null,
+        25,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "2016-05-01T00:00:00Z"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        0,
+        0,
+        null,
+        null,
+        26,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "50"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        1,
+        0,
+        null,
+        null,
+        26,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "20"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        0,
+        0,
+        null,
+        null,
+        27,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "type_2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        1,
+        0,
+        null,
+        null,
+        27,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "type_1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        2,
+        0,
+        null,
+        null,
+        27,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "type_2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        0,
+        0,
+        null,
+        null,
+        28,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "P2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        1,
+        0,
+        null,
+        null,
+        28,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "P2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        2,
+        0,
+        null,
+        null,
+        28,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "P1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        0,
+        0,
+        null,
+        null,
+        29,
+        null,
+        null,
+        9,
+        8
+      ],
+      "stringValue": "R2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        1,
+        0,
+        null,
+        null,
+        29,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "R3"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        2,
+        0,
+        null,
+        null,
+        29,
+        null,
+        null,
+        2,
+        3
+      ],
+      "stringValue": "R1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        30,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "STD1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        30,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "STD1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        30,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "STD1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        30,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "STD2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        30,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "STD1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        30,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "STD1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        30,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "STD2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        30,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "STD2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        30,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "STD2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        30,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "STD2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        31,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "http://www.example.com"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        31,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "http://www.example.com"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        31,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "http://www.example.com"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        31,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "http://www.example.com"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        31,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "http://www.example.com"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        31,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "http://www.example.com"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        31,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "http://www.example.com"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        31,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "http://www.example.com"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        31,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "http://www.example.com"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        31,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "http://www.example.com"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        32,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "STUDY1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        32,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "STUDY1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        32,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "STUDY1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        32,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "STUDY2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        32,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "STUDY1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        32,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "STUDY1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        32,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "STUDY2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        32,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "STUDY2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        32,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "STUDY2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        32,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "STUDY2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        33,
+        null,
+        null,
+        null,
+        8
+      ],
+      "stringValue": "Study 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        33,
+        null,
+        null,
+        null,
+        0
+      ],
+      "stringValue": "Study 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        33,
+        null,
+        null,
+        null,
+        1
+      ],
+      "stringValue": "Study 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        33,
+        null,
+        null,
+        null,
+        2
+      ],
+      "stringValue": "Study 2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        33,
+        null,
+        null,
+        null,
+        3
+      ],
+      "stringValue": "Study 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        0,
+        null,
+        33,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "Study 1"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        33,
+        null,
+        null,
+        null,
+        4
+      ],
+      "stringValue": "Study 2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        33,
+        null,
+        null,
+        null,
+        7
+      ],
+      "stringValue": "Study 2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        33,
+        null,
+        null,
+        null,
+        5
+      ],
+      "stringValue": "Study 2"
+    },
+    {
+      "inlineDimensions": [
+        null
+      ],
+      "dimensionIndexes": [
+        null,
+        0,
+        1,
+        null,
+        33,
+        null,
+        null,
+        null,
+        6
+      ],
+      "stringValue": "Study 2"
+    }
+  ],
+  "dimensionElements": {
+    "Radiology": [
+      "R2",
+      "R3",
+      "R1"
+    ],
+    "study": [
+      {
+        "name": "CSR"
+      }
+    ],
+    "Study": [
+      "STUDY1",
+      "STUDY2"
+    ],
+    "Biomaterial": [
+      "BM2",
+      "BM3",
+      "BM5",
+      "BM8",
+      "BM13",
+      "BM1",
+      "BM9",
+      "BM15",
+      "BM4",
+      "BM10",
+      "BM11",
+      "BM12",
+      "BM6",
+      "BM14",
+      "BM7"
+    ],
+    "concept": [
+      {
+        "conceptPath": "\\CSR\\Biomaterial.biomaterial_date",
+        "conceptCode": "Biomaterial.biomaterial_date",
+        "name": "02. Date of biomaterial"
+      },
+      {
+        "conceptPath": "\\CSR\\Biomaterial.src_biomaterial_id",
+        "conceptCode": "Biomaterial.src_biomaterial_id",
+        "name": "01. Biomaterial parent"
+      },
+      {
+        "conceptPath": "\\CSR\\Biomaterial.type",
+        "conceptCode": "Biomaterial.type",
+        "name": "03. Biomaterial type"
+      },
+      {
+        "conceptPath": "\\CSR\\Biosource.biosource_date",
+        "conceptCode": "Biosource.biosource_date",
+        "name": "02. Date of biosource"
+      },
+      {
+        "conceptPath": "\\CSR\\Biosource.biosource_dedicated",
+        "conceptCode": "Biosource.biosource_dedicated",
+        "name": "06. Biosource dedicated for specific study"
+      },
+      {
+        "conceptPath": "\\CSR\\Biosource.disease_status",
+        "conceptCode": "Biosource.disease_status",
+        "name": "04. Disease status"
+      },
+      {
+        "conceptPath": "\\CSR\\Biosource.src_biosource_id",
+        "conceptCode": "Biosource.src_biosource_id",
+        "name": "01. Biosource parent"
+      },
+      {
+        "conceptPath": "\\CSR\\Biosource.tissue",
+        "conceptCode": "Biosource.tissue",
+        "name": "03. Tissue"
+      },
+      {
+        "conceptPath": "\\CSR\\Biosource.tumor_percentage",
+        "conceptCode": "Biosource.tumor_percentage",
+        "name": "05. Tumor percentage"
+      },
+      {
+        "conceptPath": "\\CSR\\Diagnosis.diagnosis_center",
+        "conceptCode": "Diagnosis.diagnosis_center",
+        "name": "05. Center of diagnosis"
+      },
+      {
+        "conceptPath": "\\CSR\\Diagnosis.diagnosis_date",
+        "conceptCode": "Diagnosis.diagnosis_date",
+        "name": "01. Date of diagnosis"
+      },
+      {
+        "conceptPath": "\\CSR\\Diagnosis.topography",
+        "conceptCode": "Diagnosis.topography",
+        "name": "03. Topography"
+      },
+      {
+        "conceptPath": "\\CSR\\Diagnosis.treatment_protocol",
+        "conceptCode": "Diagnosis.treatment_protocol",
+        "name": "Treatment"
+      },
+      {
+        "conceptPath": "\\CSR\\Diagnosis.tumor_stage",
+        "conceptCode": "Diagnosis.tumor_stage",
+        "name": "04. Tumor stage"
+      },
+      {
+        "conceptPath": "\\CSR\\Diagnosis.tumor_type",
+        "conceptCode": "Diagnosis.tumor_type",
+        "name": "02. Tumor type"
+      },
+      {
+        "conceptPath": "\\CSR\\Individual.birth_date",
+        "conceptCode": "Individual.birth_date",
+        "name": "01. Date of birth"
+      },
+      {
+        "conceptPath": "\\CSR\\Individual.gender",
+        "conceptCode": "Individual.gender",
+        "name": "02. Sex"
+      },
+      {
+        "conceptPath": "\\CSR\\Individual.ic_given_date",
+        "conceptCode": "Individual.ic_given_date",
+        "name": "02. Date informed Consent given"
+      },
+      {
+        "conceptPath": "\\CSR\\Individual.ic_type",
+        "conceptCode": "Individual.ic_type",
+        "name": "01. Informed consent type"
+      },
+      {
+        "conceptPath": "\\CSR\\Individual.ic_withdrawn_date",
+        "conceptCode": "Individual.ic_withdrawn_date",
+        "name": "03. Date informed consent withdrawn"
+      },
+      {
+        "conceptPath": "\\CSR\\Individual.report_her_susc",
+        "conceptCode": "Individual.report_her_susc",
+        "name": "04. Report hereditary susceptibility"
+      },
+      {
+        "conceptPath": "\\CSR\\IndividualStudy.individual_study_id",
+        "conceptCode": "IndividualStudy.individual_study_id",
+        "name": "04. Individual Study ID"
+      },
+      {
+        "conceptPath": "\\CSR\\Individual.taxonomy",
+        "conceptCode": "Individual.taxonomy",
+        "name": "Taxonomy"
+      },
+      {
+        "conceptPath": "\\CSR\\Radiology.body_part",
+        "conceptCode": "Radiology.body_part",
+        "name": "06. Body Part"
+      },
+      {
+        "conceptPath": "\\CSR\\Radiology.diagnosis_id",
+        "conceptCode": "Radiology.diagnosis_id",
+        "name": "05. Diagnosis ID"
+      },
+      {
+        "conceptPath": "\\CSR\\Radiology.examination_date",
+        "conceptCode": "Radiology.examination_date",
+        "name": "01. Examination Date"
+      },
+      {
+        "conceptPath": "\\CSR\\Radiology.field_strength",
+        "conceptCode": "Radiology.field_strength",
+        "name": "03. Field Strength"
+      },
+      {
+        "conceptPath": "\\CSR\\Radiology.image_type",
+        "conceptCode": "Radiology.image_type",
+        "name": "02. Image Type"
+      },
+      {
+        "conceptPath": "\\CSR\\Radiology.individual_id",
+        "conceptCode": "Radiology.individual_id",
+        "name": "04. Individual ID"
+      },
+      {
+        "conceptPath": "\\CSR\\Radiology.radiology_id",
+        "conceptCode": "Radiology.radiology_id",
+        "name": "00. Radiology ID"
+      },
+      {
+        "conceptPath": "\\CSR\\Study.acronym",
+        "conceptCode": "Study.acronym",
+        "name": "02. Study acronym"
+      },
+      {
+        "conceptPath": "\\CSR\\Study.datadictionary",
+        "conceptCode": "Study.datadictionary",
+        "name": "Study datadictionary"
+      },
+      {
+        "conceptPath": "\\CSR\\Study.study_id",
+        "conceptCode": "Study.study_id",
+        "name": "01. Study ID"
+      },
+      {
+        "conceptPath": "\\CSR\\Study.title",
+        "conceptCode": "Study.title",
+        "name": "03. Study title"
+      }
+    ],
+    "Biosource": [
+      "BS2",
+      "BS3",
+      "BS5",
+      "BS9",
+      "BS1",
+      "BS10",
+      "BS4",
+      "BS11",
+      "BS12",
+      "BS7",
+      "BS8",
+      "BS6"
+    ],
+    "visit": [],
+    "Diagnosis": [
+      "D11",
+      "D6",
+      "D1",
+      "D10",
+      "D5",
+      "D12",
+      "D8",
+      "D9",
+      "D7",
+      "D2",
+      "D3",
+      "D13"
+    ],
+    "patient": [
+      {
+        "id": 2,
+        "trial": null,
+        "inTrialId": null,
+        "subjectIds": {
+          "SUBJ_ID": "P3"
+        },
+        "birthDate": null,
+        "deathDate": null,
+        "age": null,
+        "race": null,
+        "maritalStatus": null,
+        "religion": null,
+        "sexCd": "female",
+        "sex": "female"
+      },
+      {
+        "id": 3,
+        "trial": null,
+        "inTrialId": null,
+        "subjectIds": {
+          "SUBJ_ID": "P4"
+        },
+        "birthDate": null,
+        "deathDate": null,
+        "age": null,
+        "race": null,
+        "maritalStatus": null,
+        "religion": null,
+        "sexCd": "male",
+        "sex": "male"
+      },
+      {
+        "id": 4,
+        "trial": null,
+        "inTrialId": null,
+        "subjectIds": {
+          "SUBJ_ID": "P6"
+        },
+        "birthDate": null,
+        "deathDate": null,
+        "age": null,
+        "race": null,
+        "maritalStatus": null,
+        "religion": null,
+        "sexCd": "male",
+        "sex": "male"
+      },
+      {
+        "id": 5,
+        "trial": null,
+        "inTrialId": null,
+        "subjectIds": {
+          "SUBJ_ID": "P1"
+        },
+        "birthDate": null,
+        "deathDate": null,
+        "age": null,
+        "race": null,
+        "maritalStatus": null,
+        "religion": null,
+        "sexCd": "female",
+        "sex": "female"
+      },
+      {
+        "id": 6,
+        "trial": null,
+        "inTrialId": null,
+        "subjectIds": {
+          "SUBJ_ID": "P5"
+        },
+        "birthDate": null,
+        "deathDate": null,
+        "age": null,
+        "race": null,
+        "maritalStatus": null,
+        "religion": null,
+        "sexCd": "female",
+        "sex": "female"
+      },
+      {
+        "id": 8,
+        "trial": null,
+        "inTrialId": null,
+        "subjectIds": {
+          "SUBJ_ID": "P8"
+        },
+        "birthDate": null,
+        "deathDate": null,
+        "age": null,
+        "race": null,
+        "maritalStatus": null,
+        "religion": null,
+        "sexCd": "male",
+        "sex": "male"
+      },
+      {
+        "id": 9,
+        "trial": null,
+        "inTrialId": null,
+        "subjectIds": {
+          "SUBJ_ID": "P9"
+        },
+        "birthDate": null,
+        "deathDate": null,
+        "age": null,
+        "race": null,
+        "maritalStatus": null,
+        "religion": null,
+        "sexCd": "female",
+        "sex": "female"
+      },
+      {
+        "id": 7,
+        "trial": null,
+        "inTrialId": null,
+        "subjectIds": {
+          "SUBJ_ID": "P7"
+        },
+        "birthDate": null,
+        "deathDate": null,
+        "age": null,
+        "race": null,
+        "maritalStatus": null,
+        "religion": null,
+        "sexCd": "female",
+        "sex": "female"
+      },
+      {
+        "id": 1,
+        "trial": null,
+        "inTrialId": null,
+        "subjectIds": {
+          "SUBJ_ID": "P2"
+        },
+        "birthDate": null,
+        "deathDate": null,
+        "age": null,
+        "race": null,
+        "maritalStatus": null,
+        "religion": null,
+        "sexCd": "male",
+        "sex": "male"
+      }
+    ]
+  }
 }

--- a/tests/test_table_transformations.py
+++ b/tests/test_table_transformations.py
@@ -11,27 +11,27 @@ class CsrTranformations(unittest.TestCase):
 
     def test_result_data_shape_basic_with_sorting(self):
         self.test_data = [
-            [None, None, None, 'patient_concept_1', '\\01.Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
-            [None, None, 'D1', 'diagnosis_concept_1', '\\02.Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
+            [None, None, None, 'Individual.age', '\\01.Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
+            [None, None, 'D1', 'Diagnosis.age', '\\02.Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 1, 'P1', 'Diagnosis 1 Name', 'TEST'],
-            [None, None, 'D2', 'diagnosis_concept_1', '\\02.Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
+            [None, None, 'D2', 'Diagnosis.name', '\\02.Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 1, 'P1', 'Diagnosis 2 Name', 'TEST'],
-            [None, 'BS1', 'D1', 'biosource_concept_1', '\\03.Biosource\\Cell type\\', 'Cell type',
+            [None, 'BS1', 'D1', 'Biosource.cell_type', '\\03.Biosource\\Cell type\\', 'Cell type',
              None, 1, 'P1', 'Skin', 'TEST'],
-            ['BM1', 'BS1', 'D1', 'biomaterial_concept_1', '\\04.Biomaterial\\Date\\',
+            ['BM1', 'BS1', 'D1', 'Biomaterial.date', '\\04.Biomaterial\\Date\\',
              '01. Date of biomaterial', None, 1, 'P1', '2018-04-24T02:00:00Z', 'TEST'],
-            [None, 'BS2', 'D2', 'biosource_concept_1', '\\03.Biosource\\Cell type\\', 'Cell type',
+            [None, 'BS2', 'D2', 'Biosource.cell_type', '\\03.Biosource\\Cell type\\', 'Cell type',
              None, 1, 'P1', 'Tissue 2', 'TEST'],
-            ['BM2', 'BS2', 'D2', 'biomaterial_concept_1', '\\04.Biomaterial\\Date\\',
+            ['BM2', 'BS2', 'D2', 'Biomaterial.date', '\\04.Biomaterial\\Date\\',
              '01. Date of biomaterial', None, 1, 'P1', 'Wed Mar 07 01:00:00 CET 2018', 'TEST'],
-            [None, None, None, 'patient_concept_1', '\\01.Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
-            [None, None, 'D3', 'diagnosis_concept_1', '\\02.Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
+            [None, None, None, 'Individual.age', '\\01.Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
+            [None, None, 'D3', 'Diagnosis.name', '\\02.Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 2, 'P2', 'Diagnosis 3 Name', 'TEST'],
-            [None, 'BS3', 'D3', 'biosource_concept_1', '\\03.Biosource\\Cell type\\', 'Cell type',
+            [None, 'BS3', 'D3', 'Biosource.cell_type', '\\03.Biosource\\Cell type\\', 'Cell type',
              None, 2, 'P2', 'Liver', 'TEST'],
-            ['BM3', 'BS3', 'D3', 'biomaterial_concept_1', '\\04.Biomaterial\\Date\\',
+            ['BM3', 'BS3', 'D3', 'Biomaterial.date', '\\04.Biomaterial\\Date\\',
              '01. Date of biomaterial', None, 2, 'P2', 'Fri Jan 19 01:00:00 CET 2018', 'TEST'],
-            ['BM4', 'BS3', 'D3', 'biomaterial_concept_1', '\\04.Biomaterial\\Date\\',
+            ['BM4', 'BS3', 'D3', 'Biomaterial.date', '\\04.Biomaterial\\Date\\',
              '01. Date of biomaterial', None, 2, 'P2', 'Sun Jun 05 02:00:00 CEST 2011', 'TEST']]
         observations_df = pd.DataFrame(self.test_data, columns=['Biomaterial', 'Biosource',
                                                                 'Diagnosis', 'concept.conceptCode',
@@ -57,15 +57,15 @@ class CsrTranformations(unittest.TestCase):
 
     def test_result_data_shape_no_biomaterial_column(self):
         self.test_data = [
-            [None, None, 'patient_concept_1', '\\Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
-            [None, 'D1', 'diagnosis_concept_1', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
+            [None, None, 'Individual.age', '\\Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
+            [None, 'D1', 'Diagnosis.name', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 1, 'P1', 'Diagnosis 1 Name', 'TEST'],
-            ['BS1', 'D1', 'biosource_concept_1', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
+            ['BS1', 'D1', 'Biosource.cell_type', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
              None, 1, 'P1', 'Skin', 'TEST'],
-            [None, None, 'patient_concept_1', '\\Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
-            [None, 'D2', 'diagnosis_concept_1', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
+            [None, None, 'Individual.age', '\\Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
+            [None, 'D2', 'Diagnosis.name', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 2, 'P2', 'Diagnosis 2 Name', 'TEST'],
-            ['BS2', 'D2', 'biosource_concept_1', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
+            ['BS2', 'D2', 'Biosource.cell_type', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
              None, 2, 'P2', 'Liver', 'TEST']
             ]
         observations_df = pd.DataFrame(self.test_data, columns=['Biosource', 'Diagnosis',
@@ -78,21 +78,21 @@ class CsrTranformations(unittest.TestCase):
 
         self.assertIsNotNone(df)
         expected_df = pd.DataFrame([
-            ['P1', 'D1', 'BS1', 42., 'Skin', 'Diagnosis 1 Name'],
-            ['P2', 'D2', 'BS2', 39., 'Liver', 'Diagnosis 2 Name'],
+            ['P1', 'D1', 'BS1', 42., 'Diagnosis 1 Name', 'Skin'],
+            ['P2', 'D2', 'BS2', 39., 'Diagnosis 2 Name', 'Liver'],
         ], columns=['Subject Id', 'Diagnosis Id', 'Biosource Id',
-                    '\\Patient\\Age\\', '\\Patient\\Diagnosis\\Biosource\\Cell type\\',
-                    '\\Patient\\Diagnosis\\Diagnosis Name\\'])
+                    '\\Patient\\Age\\', '\\Patient\\Diagnosis\\Diagnosis Name\\',
+                    '\\Patient\\Diagnosis\\Biosource\\Cell type\\'])
         expected_df.set_index(['Subject Id', 'Diagnosis Id', 'Biosource Id'], inplace=True)
         pdt.assert_frame_equal(df, expected_df)
 
     def test_result_data_shape_no_biosource_no_biomaterial_columns(self):
         self.test_data = [
-            [None, 'patient_concept_1', '\\Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
-            ['D1', 'diagnosis_concept_1', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
+            [None, 'Individual.age', '\\Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
+            ['D1', 'Diagnosis.name', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 1, 'P1', 'Diagnosis 1 Name', 'TEST'],
-            [None, 'patient_concept_1', '\\Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
-            ['D2', 'diagnosis_concept_1', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
+            [None, 'Individual.age', '\\Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
+            ['D2', 'Diagnosis.name', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 2, 'P2', 'Diagnosis 2 Name', 'TEST'],
             ]
         observations_df = pd.DataFrame(self.test_data, columns=['Diagnosis',
@@ -114,8 +114,8 @@ class CsrTranformations(unittest.TestCase):
 
     def test_result_data_shape_patient_column_only(self):
         self.test_data = [
-            ['patient_concept_1', '\\Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
-            ['patient_concept_1', '\\Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
+            ['Individual.age', '\\Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
+            ['Individual.age', '\\Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
             ]
         observations_df = pd.DataFrame(self.test_data, columns=['concept.conceptCode', 'concept.conceptPath',
                                                                 'concept.name', 'numericValue',
@@ -135,19 +135,19 @@ class CsrTranformations(unittest.TestCase):
 
     def test_result_data_shape_no_diagnosis_observations_with_sorting(self):
         self.test_data = [
-            [None, None, None, 'patient_concept_1', '\\01.Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
-            [None, 'BS1', 'D1', 'biosource_concept_1', '\\03.Biosource\\Cell type\\', 'Cell type',
+            [None, None, None, 'Individual.age', '\\01.Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
+            [None, 'BS1', 'D1', 'Biosource.cell_type', '\\03.Biosource\\Cell type\\', 'Cell type',
              None, 1, 'P1', 'Skin', 'TEST'],
-            ['BM1', 'BS1', 'D1', 'biomaterial_concept_1', '\\04.Biomaterial\\Date\\',
+            ['BM1', 'BS1', 'D1', 'Biomaterial.date', '\\04.Biomaterial\\Date\\',
              '01. Date of biomaterial', None, 1, 'P1', '2018-04-24T02:00:00Z', 'TEST'],
-            ['BM2', 'BS1', 'D1', 'biomaterial_concept_1', '\\04.Biomaterial\\Date\\',
+            ['BM2', 'BS1', 'D1', 'Biomaterial.date', '\\04.Biomaterial\\Date\\',
              '01. Date of biomaterial', None, 1, 'P1', '2018-03-07T01:00:00Z', 'TEST'],
-            [None, None, None, 'patient_concept_1', '\\01.Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
-            [None, 'BS2', 'D2', 'biosource_concept_1', '\\03.Biosource\\Cell type\\', 'Cell type',
+            [None, None, None, 'Individual.age', '\\01.Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
+            [None, 'BS2', 'D2', 'Biosource.cell_type', '\\03.Biosource\\Cell type\\', 'Cell type',
              None, 2, 'P2', 'Liver', 'TEST'],
-            ['BM3', 'BS2', 'D2', 'biomaterial_concept_1', '\\04.Biomaterial\\Date\\',
+            ['BM3', 'BS2', 'D2', 'Biomaterial.date', '\\04.Biomaterial\\Date\\',
              '01. Date of biomaterial', None, 2, 'P2', '2018-01-19T01:00:00Z', 'TEST'],
-            ['BM4', 'BS2', 'D2', 'biomaterial_concept_1', '\\04.Biomaterial\\Date\\',
+            ['BM4', 'BS2', 'D2', 'Biomaterial.date', '\\04.Biomaterial\\Date\\',
              '01. Date of biomaterial', None, 2, 'P2', '2011-06-05T02:00:00Z', 'TEST']]
         observations_df = pd.DataFrame(self.test_data, columns=['Biomaterial', 'Biosource',
                                                                 'Diagnosis', 'concept.conceptCode',
@@ -178,11 +178,11 @@ class CsrTranformations(unittest.TestCase):
 
     def test_concept_path_respected(self):
         self.test_data = [
-            ['dname', '\\02. Diagnosis\\Name\\', 'Name', None, 1, 'P1', 'Diagnosis 1', 'TEST'],
-            ['bsname', '\\03. Biosource\\Name\\', 'Name', None, 1, 'P1', 'Biosource 1', 'TEST'],
-            ['pname', '\\01. Patient\\Name\\', 'Name', None, 1, 'P1', 'Patient 1', 'TEST'],
-            ['bmname', '\\04. Biomaterial\\Name\\', 'Name', None, 1, 'P1', 'Biomaterial 1', 'TEST'],
-            ['pname', '\\01. Patient\\Name\\', 'Name', None, 2, 'P2', 'Patient 2', 'TEST'],
+            ['Diagnosis.name', '\\02. Diagnosis\\Name\\', 'Name', None, 1, 'P1', 'Diagnosis 1', 'TEST'],
+            ['Biosource.name', '\\03. Biosource\\Name\\', 'Name', None, 1, 'P1', 'Biosource 1', 'TEST'],
+            ['Individual.name', '\\01. Patient\\Name\\', 'Name', None, 1, 'P1', 'Patient 1', 'TEST'],
+            ['Biomaterial.name', '\\04. Biomaterial\\Name\\', 'Name', None, 1, 'P1', 'Biomaterial 1', 'TEST'],
+            ['Individual.name', '\\01. Patient\\Name\\', 'Name', None, 2, 'P2', 'Patient 2', 'TEST'],
         ]
         observations_df = pd.DataFrame(self.test_data, columns=['concept.conceptCode', 'concept.conceptPath',
                                                                 'concept.name', 'numericValue', 'patient.id',
@@ -203,17 +203,17 @@ class CsrTranformations(unittest.TestCase):
 
     def test_values_propagation(self):
         self.test_data = [
-            [1, 'P1', None, None, None, 'ptxt', '\\01. Patient\\Text\\', 'Text', None, 'Patient #1', 'T'],
-            [1, 'P1', None, None, None, 'pnum', '\\01. Patient\\Number\\', 'Number', 5., None, 'T'],
-            [1, 'P1', 'D1', None, None, 'dtxt', '\\02. Diagnosis\\Text\\', 'Text', None, 'Diagnosis #1', 'T'],
-            [1, 'P1', 'D2', None, None, 'dnum', '\\02. Diagnosis\\Number\\', 'Number', 10., None, 'T'],
-            [1, 'P1', 'D2', None, None, 'dtxt', '\\02. Diagnosis\\Text\\', 'Text', None, 'Diagnosis #2', 'T'],
-            [1, 'P1', 'D1', 'BS1', None, 'bsnum', '\\03. Biosource\\Number\\', 'Number', 15., None, 'T'],
-            [1, 'P1', 'D1', 'BS1', None, 'bstxt', '\\03. Biosource\\Text\\', 'Text', None, 'Biosource #1', 'T'],
-            [1, 'P1', 'D2', 'BS2', None, 'bsnum', '\\03. Biosource\\Number\\', 'Number', 20., None, 'T'],
-            [1, 'P1', 'D1', 'BS1', 'BM1', 'bmnum', '\\04. Biomaterial\\Number\\', 'Number', 25., None, 'T'],
-            [1, 'P1', 'D1', 'BS1', 'BM1', 'bmtxt', '\\04. Biomaterial\\Text\\', 'Text', None, 'Biomaterial #1', 'T'],
-            [1, 'P1', 'D1', 'BS1', 'BM2', 'bmtxt', '\\04. Biomaterial\\Text\\', 'Text', None, 'Biomaterial #2', 'T'],
+            [1, 'P1', None, None, None, 'Individual.text', '\\01. Patient\\Text\\', 'Text', None, 'Patient #1', 'T'],
+            [1, 'P1', None, None, None, 'Individual.number', '\\01. Patient\\Number\\', 'Number', 5., None, 'T'],
+            [1, 'P1', 'D1', None, None, 'Diagnosis.text', '\\02. Diagnosis\\Text\\', 'Text', None, 'Diagnosis #1', 'T'],
+            [1, 'P1', 'D2', None, None, 'Diagnosis.number', '\\02. Diagnosis\\Number\\', 'Number', 10., None, 'T'],
+            [1, 'P1', 'D2', None, None, 'Diagnosis.text', '\\02. Diagnosis\\Text\\', 'Text', None, 'Diagnosis #2', 'T'],
+            [1, 'P1', 'D1', 'BS1', None, 'Biosource.number', '\\03. Biosource\\Number\\', 'Number', 15., None, 'T'],
+            [1, 'P1', 'D1', 'BS1', None, 'Biosource.text', '\\03. Biosource\\Text\\', 'Text', None, 'Biosource #1', 'T'],
+            [1, 'P1', 'D2', 'BS2', None, 'Biosource.number', '\\03. Biosource\\Number\\', 'Number', 20., None, 'T'],
+            [1, 'P1', 'D1', 'BS1', 'BM1', 'Biomaterial.number', '\\04. Biomaterial\\Number\\', 'Number', 25., None, 'T'],
+            [1, 'P1', 'D1', 'BS1', 'BM1', 'Biomaterial.text', '\\04. Biomaterial\\Text\\', 'Text', None, 'Biomaterial #1', 'T'],
+            [1, 'P1', 'D1', 'BS1', 'BM2', 'Biomaterial.text', '\\04. Biomaterial\\Text\\', 'Text', None, 'Biomaterial #2', 'T'],
 
             [2, 'P2', None, None, None, 'pnum', '\\01. Patient\\Number\\', 'Number', 30., None, 'T'],
             [2, 'P2', 'D3', None, None, 'dnum', '\\02. Diagnosis\\Number\\', 'Number', 35., None, 'T'],
@@ -274,9 +274,9 @@ class CsrTranformations(unittest.TestCase):
 
     def test_diagnoseless_biosources(self):
         self.test_data = [
-            ['BS1', 'D1', 'biosource_concept_1', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
+            ['BS1', 'D1', 'Biosource.cell_type', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
              None, 1, 'P1', 'Skin', 'TEST'],
-            ['BS2', None, 'biosource_concept_1', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
+            ['BS2', None, 'Biosource.cell_type', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
              None, 2, 'P2', 'Liver', 'TEST']
             ]
         observations_df = pd.DataFrame(self.test_data, columns=['Biosource', 'Diagnosis',
@@ -304,48 +304,49 @@ class CsrTranformations(unittest.TestCase):
 
         self.assertIsNotNone(df)
         actual_ids = list(df.index.values)
+        df.to_csv('test_result.tsv', sep='\t')
         self.assertEqual(actual_ids, [
-            ('P1', 'D1', 'BS1', 'BM1', 'STUDY1'),
-            ('P1', 'D10', 'BS10', 'BM15', 'STUDY1'),
-            ('P1', 'D10', 'BS10', 'BM9', 'STUDY1'),
-            ('P2', 'D2', '', '', 'STUDY1'),
-            ('P3', 'D11', 'BS2', 'BM2', 'STUDY1'),
-            ('P3', 'D3', '', '', 'STUDY1'),
-            ('P4', '', 'BS3', 'BM3', 'STUDY1'),
-            ('P5', 'D12', 'BS11', 'BM10', 'STUDY1'),
-            ('P5', 'D12', 'BS11', 'BM10', 'STUDY2'),
-            ('P5', 'D5', 'BS12', 'BM11', 'STUDY1'),
-            ('P5', 'D5', 'BS12', 'BM11', 'STUDY2'),
-            ('P5', 'D5', 'BS4', 'BM12', 'STUDY1'),
-            ('P5', 'D5', 'BS4', 'BM12', 'STUDY2'),
-            ('P5', 'D5', 'BS4', 'BM4', 'STUDY1'),
-            ('P5', 'D5', 'BS4', 'BM4', 'STUDY2'),
-            ('P6', 'D6', 'BS5', 'BM13', 'STUDY2'),
-            ('P6', 'D6', 'BS5', 'BM5', 'STUDY2'),
-            ('P6', 'D6', 'BS9', 'BM8', 'STUDY2'),
-            ('P7', 'D13', '', '', 'STUDY2'),
-            ('P7', 'D7', 'BS6', '', 'STUDY2'),
-            ('P8', 'D8', 'BS7', 'BM14', 'STUDY2'),
-            ('P8', 'D8', 'BS7', 'BM6', 'STUDY2'),
-            ('P9', 'D9', 'BS8', 'BM7', 'STUDY2')])
+            ('P1', 'D1', 'BS1', 'BM1', 'R1', 'STUDY1'),
+            ('P1', 'D10', 'BS10', 'BM15', '', 'STUDY1'),
+            ('P1', 'D10', 'BS10', 'BM9', '', 'STUDY1'),
+            ('P2', 'D2', '', '', 'R2', 'STUDY1'),
+            ('P2', '', '', '', 'R3', 'STUDY1'),
+            ('P3', 'D11', 'BS2', 'BM2', '', 'STUDY1'),
+            ('P3', 'D3', '', '', '', 'STUDY1'),
+            ('P4', '', 'BS3', 'BM3', '', 'STUDY1'),
+            ('P5', 'D12', 'BS11', 'BM10', '', 'STUDY1'),
+            ('P5', 'D12', 'BS11', 'BM10', '', 'STUDY2'),
+            ('P5', 'D5', 'BS12', 'BM11', '', 'STUDY1'),
+            ('P5', 'D5', 'BS12', 'BM11', '', 'STUDY2'),
+            ('P5', 'D5', 'BS4', 'BM12', '', 'STUDY1'),
+            ('P5', 'D5', 'BS4', 'BM12', '', 'STUDY2'),
+            ('P5', 'D5', 'BS4', 'BM4', '', 'STUDY1'),
+            ('P5', 'D5', 'BS4', 'BM4', '', 'STUDY2'),
+            ('P6', 'D6', 'BS5', 'BM13', '', 'STUDY2'),
+            ('P6', 'D6', 'BS5', 'BM5', '', 'STUDY2'),
+            ('P6', 'D6', 'BS9', 'BM8', '', 'STUDY2'),
+            ('P7', 'D13', '', '', '', 'STUDY2'),
+            ('P7', 'D7', 'BS6', '', '', 'STUDY2'),
+            ('P8', 'D8', 'BS7', 'BM14', '', 'STUDY2'),
+            ('P8', 'D8', 'BS7', 'BM6', '', 'STUDY2'),
+            ('P9', 'D9', 'BS8', 'BM7', '', 'STUDY2')
+        ])
         columns = list(df.columns.values)
         self.assertEqual(columns, [
             # patient
             '01. Date of birth',
-            '02. Sex',
             '01. Informed consent type',
+            '02. Date informed Consent given',
+            '02. Sex',
             '03. Date informed consent withdrawn',
-            '04. Informed consent material',
-            '05. Informed consent data',
-            '06. Informed concent linking external database',
-            '07. Report heriditary susceptibility',
+            '04. Report hereditary susceptibility',
             'Taxonomy',
             # diagnosis
             '01. Date of diagnosis',
             '02. Tumor type',
             '03. Topography',
             '04. Tumor stage',
-            '05. Center of treatment',
+            '05. Center of diagnosis',
             'Treatment',
             # biosource
             '01. Biosource parent',
@@ -358,19 +359,29 @@ class CsrTranformations(unittest.TestCase):
             '01. Biomaterial parent',
             '02. Date of biomaterial',
             '03. Biomaterial type',
+            # radiology
+            '00. Radiology ID',
+            '01. Examination Date',
+            '02. Image Type',
+            '03. Field Strength',
+            '04. Individual ID',
+            '05. Diagnosis ID',
+            '06. Body Part',
             # study
             '01. Study ID',
             '02. Study acronym',
             '03. Study title',
-            '04. Individual Study ID'])
+            'Study datadictionary',
+            '04. Individual Study ID'
+        ])
         p5_study1_data = list(df.loc[
-            ('P5', 'D12', 'BS11', 'BM10', 'STUDY1'),
+            ('P5', 'D12', 'BS11', 'BM10', '', 'STUDY1'),
             ['01. Study ID', '02. Study acronym', '03. Study title', '04. Individual Study ID']].values)
         self.assertEqual(p5_study1_data, ['STUDY1', 'STD1', 'Study 1', '5'])
         p5_study2_data = list(df.loc[
-            ('P5', 'D12', 'BS11', 'BM10', 'STUDY2'),
+            ('P5', 'D12', 'BS11', 'BM10', '', 'STUDY2'),
             ['01. Study ID', '02. Study acronym', '03. Study title', '04. Individual Study ID']].values)
-        self.assertEqual(p5_study2_data, ['STUDY2', 'STD2', 'Study 2', '6'])
+        self.assertEqual(p5_study2_data, ['STUDY2', 'STD2', 'Study 2', '1'])
 
 
 if __name__ == '__main__':

--- a/tests/test_table_transformations.py
+++ b/tests/test_table_transformations.py
@@ -1,6 +1,6 @@
 import unittest
 from packer.table_transformations.csr_transformations import \
-    from_obs_df_to_csr_df, format_columns, from_obs_json_to_export_csr_df
+    from_obs_df_to_csr_df, format_columns, from_obs_json_to_export_csr_df, transform_obs_df
 import pandas as pd
 import pandas.testing as pdt
 import os
@@ -10,7 +10,7 @@ import json
 class CsrTranformations(unittest.TestCase):
 
     def test_result_data_shape_basic_with_sorting(self):
-        self.test_data = [
+        test_data = [
             [None, None, None, 'Individual.age', '\\01.Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
             [None, None, 'D1', 'Diagnosis.age', '\\02.Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 1, 'P1', 'Diagnosis 1 Name', 'TEST'],
@@ -33,7 +33,7 @@ class CsrTranformations(unittest.TestCase):
              '01. Date of biomaterial', None, 2, 'P2', 'Fri Jan 19 01:00:00 CET 2018', 'TEST'],
             ['BM4', 'BS3', 'D3', 'Biomaterial.date', '\\04.Biomaterial\\Date\\',
              '01. Date of biomaterial', None, 2, 'P2', 'Sun Jun 05 02:00:00 CEST 2011', 'TEST']]
-        observations_df = pd.DataFrame(self.test_data, columns=['Biomaterial', 'Biosource',
+        observations_df = pd.DataFrame(test_data, columns=['Biomaterial', 'Biosource',
                                                                 'Diagnosis', 'concept.conceptCode',
                                                                 'concept.conceptPath', 'concept.name',
                                                                 'numericValue',
@@ -56,7 +56,7 @@ class CsrTranformations(unittest.TestCase):
 
 
     def test_result_data_shape_no_biomaterial_column(self):
-        self.test_data = [
+        test_data = [
             [None, None, 'Individual.age', '\\Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
             [None, 'D1', 'Diagnosis.name', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 1, 'P1', 'Diagnosis 1 Name', 'TEST'],
@@ -68,11 +68,11 @@ class CsrTranformations(unittest.TestCase):
             ['BS2', 'D2', 'Biosource.cell_type', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
              None, 2, 'P2', 'Liver', 'TEST']
             ]
-        observations_df = pd.DataFrame(self.test_data, columns=['Biosource', 'Diagnosis',
-                                                                'concept.conceptCode', 'concept.conceptPath',
-                                                                'concept.name', 'numericValue',
-                                                                'patient.id', 'patient.subjectIds.SUBJ_ID',
-                                                                'stringValue', 'study.name'])
+        observations_df = pd.DataFrame(test_data, columns=['Biosource', 'Diagnosis',
+                                                           'concept.conceptCode', 'concept.conceptPath',
+                                                           'concept.name', 'numericValue',
+                                                           'patient.id', 'patient.subjectIds.SUBJ_ID',
+                                                           'stringValue', 'study.name'])
 
         df = from_obs_df_to_csr_df(observations_df)
 
@@ -87,7 +87,7 @@ class CsrTranformations(unittest.TestCase):
         pdt.assert_frame_equal(df, expected_df)
 
     def test_result_data_shape_no_biosource_no_biomaterial_columns(self):
-        self.test_data = [
+        test_data = [
             [None, 'Individual.age', '\\Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
             ['D1', 'Diagnosis.name', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 1, 'P1', 'Diagnosis 1 Name', 'TEST'],
@@ -95,11 +95,11 @@ class CsrTranformations(unittest.TestCase):
             ['D2', 'Diagnosis.name', '\\Patient\\Diagnosis\\Diagnosis Name\\', 'Diagnosis Name',
              None, 2, 'P2', 'Diagnosis 2 Name', 'TEST'],
             ]
-        observations_df = pd.DataFrame(self.test_data, columns=['Diagnosis',
-                                                                'concept.conceptCode', 'concept.conceptPath',
-                                                                'concept.name', 'numericValue',
-                                                                'patient.id', 'patient.subjectIds.SUBJ_ID',
-                                                                'stringValue', 'study.name'])
+        observations_df = pd.DataFrame(test_data, columns=['Diagnosis',
+                                                           'concept.conceptCode', 'concept.conceptPath',
+                                                           'concept.name', 'numericValue',
+                                                           'patient.id', 'patient.subjectIds.SUBJ_ID',
+                                                           'stringValue', 'study.name'])
 
         df = from_obs_df_to_csr_df(observations_df)
 
@@ -113,14 +113,14 @@ class CsrTranformations(unittest.TestCase):
         pdt.assert_frame_equal(df, expected_df)
 
     def test_result_data_shape_patient_column_only(self):
-        self.test_data = [
+        test_data = [
             ['Individual.age', '\\Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
-            ['Individual.age', '\\Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST'],
-            ]
-        observations_df = pd.DataFrame(self.test_data, columns=['concept.conceptCode', 'concept.conceptPath',
-                                                                'concept.name', 'numericValue',
-                                                                'patient.id', 'patient.subjectIds.SUBJ_ID',
-                                                                'stringValue', 'study.name'])
+            ['Individual.age', '\\Patient\\Age\\', 'Age', 39.0, 2, 'P2', None, 'TEST']
+        ]
+        observations_df = pd.DataFrame(test_data, columns=['concept.conceptCode', 'concept.conceptPath',
+                                                           'concept.name', 'numericValue',
+                                                           'patient.id', 'patient.subjectIds.SUBJ_ID',
+                                                           'stringValue', 'study.name'])
 
         df = from_obs_df_to_csr_df(observations_df)
 
@@ -134,7 +134,7 @@ class CsrTranformations(unittest.TestCase):
         pdt.assert_frame_equal(df, expected_df)
 
     def test_result_data_shape_no_diagnosis_observations_with_sorting(self):
-        self.test_data = [
+        test_data = [
             [None, None, None, 'Individual.age', '\\01.Patient\\Age\\', 'Age', 42.0, 1, 'P1', None, 'TEST'],
             [None, 'BS1', 'D1', 'Biosource.cell_type', '\\03.Biosource\\Cell type\\', 'Cell type',
              None, 1, 'P1', 'Skin', 'TEST'],
@@ -149,12 +149,12 @@ class CsrTranformations(unittest.TestCase):
              '01. Date of biomaterial', None, 2, 'P2', '2018-01-19T01:00:00Z', 'TEST'],
             ['BM4', 'BS2', 'D2', 'Biomaterial.date', '\\04.Biomaterial\\Date\\',
              '01. Date of biomaterial', None, 2, 'P2', '2011-06-05T02:00:00Z', 'TEST']]
-        observations_df = pd.DataFrame(self.test_data, columns=['Biomaterial', 'Biosource',
-                                                                'Diagnosis', 'concept.conceptCode',
-                                                                'concept.conceptPath', 'concept.name',
-                                                                'numericValue',
-                                                                'patient.id', 'patient.subjectIds.SUBJ_ID',
-                                                                'stringValue', 'study.name'])
+        observations_df = pd.DataFrame(test_data, columns=['Biomaterial', 'Biosource',
+                                                           'Diagnosis', 'concept.conceptCode',
+                                                           'concept.conceptPath', 'concept.name',
+                                                           'numericValue',
+                                                           'patient.id', 'patient.subjectIds.SUBJ_ID',
+                                                           'stringValue', 'study.name'])
 
         df = from_obs_df_to_csr_df(observations_df)
 
@@ -163,7 +163,7 @@ class CsrTranformations(unittest.TestCase):
             ['P1', 'D1', 'BS1', 'BM1', 42., 'Skin', '2018-04-24T02:00:00Z'],
             ['P1', 'D1', 'BS1', 'BM2', 42., 'Skin', '2018-03-07T01:00:00Z'],
             ['P2', 'D2', 'BS2', 'BM3', 39., 'Liver', '2018-01-19T01:00:00Z'],
-            ['P2', 'D2', 'BS2', 'BM4', 39., 'Liver', '2011-06-05T02:00:00Z'],
+            ['P2', 'D2', 'BS2', 'BM4', 39., 'Liver', '2011-06-05T02:00:00Z']
         ], columns=['Subject Id', 'Diagnosis Id', 'Biosource Id', 'Biomaterial Id',
                     '\\01.Patient\\Age\\', '\\03.Biosource\\Cell type\\', '\\04.Biomaterial\\Date\\'])
         expected_df.set_index(['Subject Id', 'Diagnosis Id', 'Biosource Id', 'Biomaterial Id'], inplace=True)
@@ -177,24 +177,24 @@ class CsrTranformations(unittest.TestCase):
         self.assertEqual(result_obs.size, 0)
 
     def test_concept_path_respected(self):
-        self.test_data = [
+        test_data = [
             ['Diagnosis.name', '\\02. Diagnosis\\Name\\', 'Name', None, 1, 'P1', 'Diagnosis 1', 'TEST'],
             ['Biosource.name', '\\03. Biosource\\Name\\', 'Name', None, 1, 'P1', 'Biosource 1', 'TEST'],
             ['Individual.name', '\\01. Patient\\Name\\', 'Name', None, 1, 'P1', 'Patient 1', 'TEST'],
             ['Biomaterial.name', '\\04. Biomaterial\\Name\\', 'Name', None, 1, 'P1', 'Biomaterial 1', 'TEST'],
-            ['Individual.name', '\\01. Patient\\Name\\', 'Name', None, 2, 'P2', 'Patient 2', 'TEST'],
+            ['Individual.name', '\\01. Patient\\Name\\', 'Name', None, 2, 'P2', 'Patient 2', 'TEST']
         ]
-        observations_df = pd.DataFrame(self.test_data, columns=['concept.conceptCode', 'concept.conceptPath',
-                                                                'concept.name', 'numericValue', 'patient.id',
-                                                                'patient.subjectIds.SUBJ_ID', 'stringValue',
-                                                                'study.name'])
+        observations_df = pd.DataFrame(test_data, columns=['concept.conceptCode', 'concept.conceptPath',
+                                                           'concept.name', 'numericValue', 'patient.id',
+                                                           'patient.subjectIds.SUBJ_ID', 'stringValue',
+                                                           'study.name'])
 
         df = from_obs_df_to_csr_df(observations_df)
 
         self.assertIsNotNone(df)
         expected_df = pd.DataFrame([
             ['P1', 'Patient 1', 'Diagnosis 1', 'Biosource 1', 'Biomaterial 1'],
-            ['P2', 'Patient 2', None, None, None],
+            ['P2', 'Patient 2', None, None, None]
         ], columns=['Subject Id',
                     '\\01. Patient\\Name\\', '\\02. Diagnosis\\Name\\', '\\03. Biosource\\Name\\',
                     '\\04. Biomaterial\\Name\\'])
@@ -202,7 +202,7 @@ class CsrTranformations(unittest.TestCase):
         pdt.assert_frame_equal(df, expected_df)
 
     def test_values_propagation(self):
-        self.test_data = [
+        test_data = [
             [1, 'P1', None, None, None, 'Individual.text', '\\01. Patient\\Text\\', 'Text', None, 'Patient #1', 'T'],
             [1, 'P1', None, None, None, 'Individual.number', '\\01. Patient\\Number\\', 'Number', 5., None, 'T'],
             [1, 'P1', 'D1', None, None, 'Diagnosis.text', '\\02. Diagnosis\\Text\\', 'Text', None, 'Diagnosis #1', 'T'],
@@ -216,9 +216,9 @@ class CsrTranformations(unittest.TestCase):
             [1, 'P1', 'D1', 'BS1', 'BM2', 'Biomaterial.text', '\\04. Biomaterial\\Text\\', 'Text', None, 'Biomaterial #2', 'T'],
 
             [2, 'P2', None, None, None, 'pnum', '\\01. Patient\\Number\\', 'Number', 30., None, 'T'],
-            [2, 'P2', 'D3', None, None, 'dnum', '\\02. Diagnosis\\Number\\', 'Number', 35., None, 'T'],
+            [2, 'P2', 'D3', None, None, 'dnum', '\\02. Diagnosis\\Number\\', 'Number', 35., None, 'T']
         ]
-        observations_df = pd.DataFrame(self.test_data, columns=[
+        observations_df = pd.DataFrame(test_data, columns=[
             'patient.id', 'patient.subjectIds.SUBJ_ID', 'Diagnosis', 'Biosource', 'Biomaterial',
             'concept.conceptCode', 'concept.conceptPath', 'concept.name', 'numericValue', 'stringValue', 'study.name'])
 
@@ -231,7 +231,7 @@ class CsrTranformations(unittest.TestCase):
             ['P1', 'D1', 'BS1', 'BM2', 5., 'Patient #1', None, 'Diagnosis #1', 15., 'Biosource #1', None,
              'Biomaterial #2'],
             ['P1', 'D2', 'BS2', '', 5., 'Patient #1', 10, 'Diagnosis #2', 20, None, None, None],
-            ['P2', 'D3', '', '', 30., None, 35., None, None, None, None, None],
+            ['P2', 'D3', '', '', 30., None, 35., None, None, None, None, None]
         ], columns=['Subject Id', 'Diagnosis Id', 'Biosource Id', 'Biomaterial Id',
                     '\\01. Patient\\Number\\', '\\01. Patient\\Text\\', '\\02. Diagnosis\\Number\\',
                     '\\02. Diagnosis\\Text\\',
@@ -245,7 +245,7 @@ class CsrTranformations(unittest.TestCase):
             {
                 '01. Date of smth': ['2018-04-24T02:00:00Z', 'Wed Mar 07 01:00:00 CET 2018', 'NA', None],
                 '02. Number': [None, 30.0, 2.00001, 7.5],
-                '03. Text': ['1.0', 'yes', '', 'Wed Mar 07 01:00:00 CET 2018'],
+                '03. Text': ['1.0', 'yes', '', 'Wed Mar 07 01:00:00 CET 2018']
             })
 
         frmt_df = format_columns(src_df)
@@ -269,21 +269,21 @@ class CsrTranformations(unittest.TestCase):
         pdt.assert_frame_equal(frmt_df, pd.DataFrame(
             [
                 ['1', ''],
-                ['', '2'],
+                ['', '2']
             ], columns=['Number', 'Number']))
 
     def test_diagnoseless_biosources(self):
-        self.test_data = [
+        test_data = [
             ['BS1', 'D1', 'Biosource.cell_type', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
              None, 1, 'P1', 'Skin', 'TEST'],
             ['BS2', None, 'Biosource.cell_type', '\\Patient\\Diagnosis\\Biosource\\Cell type\\', 'Cell type',
              None, 2, 'P2', 'Liver', 'TEST']
             ]
-        observations_df = pd.DataFrame(self.test_data, columns=['Biosource', 'Diagnosis',
-                                                                'concept.conceptCode', 'concept.conceptPath',
-                                                                'concept.name', 'numericValue',
-                                                                'patient.id', 'patient.subjectIds.SUBJ_ID',
-                                                                'stringValue', 'study.name'])
+        observations_df = pd.DataFrame(test_data, columns=['Biosource', 'Diagnosis',
+                                                           'concept.conceptCode', 'concept.conceptPath',
+                                                           'concept.name', 'numericValue',
+                                                           'patient.id', 'patient.subjectIds.SUBJ_ID',
+                                                           'stringValue', 'study.name'])
 
         df = from_obs_df_to_csr_df(observations_df)
 
@@ -296,6 +296,95 @@ class CsrTranformations(unittest.TestCase):
         expected_df.set_index(['Subject Id', 'Diagnosis Id', 'Biosource Id'], inplace=True)
         pdt.assert_frame_equal(df, expected_df)
 
+    def test_result_data_shape_patient_radiology(self):
+        test_data = [
+            ['P1', None, 'Individual.gender', '\\01.Subject\\Gender\\', 'Gender', 'Female', None, 1, 'TEST'],
+            ['P2', None, 'Individual.gender', '\\01.Subject\\Gender\\', 'Gender', 'Male', None, 1, 'TEST'],
+            ['P1', 'R1', 'Radiology.image_type', '\\03.Radiology\\Image type\\', 'Image type', None, 'type_1', 1, 'TEST'],
+            ['P1', 'R1', 'Radiology.body_part', '\\03.Radiology\\Body part\\', 'Body part', None, 'torso', 1, 'TEST'],
+            ['P1', 'R2', 'Radiology.body_part', '\\03.Radiology\\Body part\\', 'Body part', None, 'legs', 1, 'TEST'],
+            ['P2', 'R3', 'Radiology.body_part', '\\03.Radiology\\Image type\\', 'Image type', None, 'type_1', 1, 'TEST']
+        ]
+        observations_df = pd.DataFrame(test_data, columns=['patient.subjectIds.SUBJ_ID',
+                                                                'Radiology',
+                                                                'concept.conceptCode', 'concept.conceptPath',
+                                                                'concept.name', 'numericValue',
+                                                                'stringValue', 'patient.id', 'study.name'])
+        df = transform_obs_df(observations_df)
+
+        self.assertIsNotNone(df)
+        expected_df = pd.DataFrame([
+            ['P1', 'R1', 'Female', 'type_1', 'torso'],
+            ['P1', 'R2', 'Female', '', 'legs'],
+            ['P2', 'R3', 'Male', 'type_1', '']
+        ], columns=['Subject Id', 'Radiology Id',
+                    'Gender', 'Image type', 'Body part'])
+        expected_df.set_index(['Subject Id', 'Radiology Id'], inplace=True)
+        pdt.assert_frame_equal(df, expected_df, check_dtype=False, check_categorical=False, check_like=True)
+
+
+    def test_result_data_shape_patient_diagnosis_radiology(self):
+        test_data = [
+            ['P1', None, None, 'Individual.gender', '\\01.Subject\\Gender\\', 'Gender', None, 'Female', 1, 'TEST'],
+            ['P1', 'D1', None, 'Diagnosis.name', '\\02.Diagnosis\\Name\\', 'Diagnosis', None, 'Leukemia', 1, 'TEST'],
+            ['P1', None, 'R1', 'Radiology.image_type', '\\03.Radiology\\Image type\\', 'Image type', None, 'type_1', 1, 'TEST']
+        ]
+        observations_df = pd.DataFrame(test_data, columns=['patient.subjectIds.SUBJ_ID', 'Diagnosis', 'Radiology',
+                                                           'concept.conceptCode', 'concept.conceptPath',
+                                                           'concept.name', 'numericValue',
+                                                           'stringValue', 'patient.id', 'study.name'])
+
+        df = transform_obs_df(observations_df)
+
+        self.assertIsNotNone(df)
+        expected_df = pd.DataFrame([
+            ['P1', '', 'R1', '', 'type_1', ''],
+            ['P1', 'D1', '', 'Female', '', 'Leukemia'],
+        ], columns=['Subject Id', 'Diagnosis Id', 'Radiology Id',
+                    'Gender', 'Image type', 'Diagnosis'])
+        expected_df.set_index(['Subject Id', 'Diagnosis Id', 'Radiology Id'], inplace=True)
+        pdt.assert_frame_equal(df, expected_df, check_dtype=False, check_categorical=False, check_like=True)
+
+
+    def test_result_data_shape_patient_diagnosis_radiology_study(self):
+        test_data = [
+            ['P1', None, None, None, 'Individual.gender', '\\01.Subject\\Gender\\', 'Gender', 'Female', None, 1, 'TEST'],
+            ['P1', 'D1', None, None, 'Diagnosis.name', '\\02.Diagnosis\\Name\\', 'Diagnosis', None, 'Leukemia', 1, 'TEST'],
+            ['P1', 'D2', None, None, 'Diagnosis.name', '\\02.Diagnosis\\Name\\', 'Diagnosis', None, 'CRC', 1, 'TEST'],
+            ['P1', 'D1', 'R1', None, 'Radiology.examination_date', '\\03.Radiology\\Examination Date\\', 'Radiology date', None, '2021-12-17T00:00:00Z', 1, 'TEST'],
+            ['P1', 'D1', 'R2', None, 'Radiology.examination_date', '\\03.Radiology\\Examination Date\\', 'Radiology date', None, '2020-07-12T00:00:00Z', 1, 'TEST'],
+            ['P1', None, 'R3', None, 'Radiology.examination_date', '\\03.Radiology\\Examination Date\\', 'Radiology date', None, '2021-12-24T00:00:00Z', 1, 'TEST'],
+            ['P1', 'D2', 'R4', None, 'Radiology.examination_date', '\\03.Radiology\\Examination Date\\', 'Radiology date', None, '2021-12-23T00:00:00Z', 1, 'TEST'],
+            ['P1', 'D1', None, None, 'Diagnosis.treatment_protocol', '\\02.Diagnosis\\treatment_protocol\\', 'Treatment', None, 'Chemo', 1, 'TEST'],
+            ['P1', None, None, 'Study1', 'Study.title', '\\Study\\Title\\', 'Study title',  None, 'Study 1', 1, 'TEST'],
+            ['P1', None, None, 'Study2', 'Study.title', '\\Study\\Title\\', 'Study title', None, 'Study 2', 1, 'TEST'],
+            ['P1', None, None, 'Study1', 'IndividualStudy.individual_study_id', '\\IndividualStudy\\individual_study_id\\', 'Individual study id', None, '1', 1, 'TEST'],
+            ['P1', None, None, 'Study2', 'IndividualStudy.individual_study_id', '\\IndividualStudy\\individual_study_id\\', 'Individual study id',None, '2', 1, 'TEST']
+        ]
+        observations_df = pd.DataFrame(test_data, columns=['patient.subjectIds.SUBJ_ID',
+                                                           'Diagnosis', 'Radiology', 'Study',
+                                                           'concept.conceptCode', 'concept.conceptPath',
+                                                           'concept.name', 'numericValue',
+                                                           'stringValue', 'patient.id', 'study.name'])
+
+        df = transform_obs_df(observations_df)
+
+        self.assertIsNotNone(df)
+        expected_df = pd.DataFrame([
+            ['P1', 'D1', 'R1', 'Study1',  'Female', 'Leukemia', 'Chemo', '2021-12-17', 'Study 1', '1'],
+            ['P1', 'D1', 'R1', 'Study2', 'Female', 'Leukemia', 'Chemo', '2021-12-17', 'Study 2', '2'],
+            ['P1', 'D1', 'R2', 'Study1',  'Female', 'Leukemia', 'Chemo', '2020-07-12', 'Study 1', '1'],
+            ['P1', 'D1', 'R2', 'Study2', 'Female', 'Leukemia', 'Chemo', '2020-07-12', 'Study 2', '2'],
+            ['P1', 'D2', 'R4', 'Study1', 'Female', 'CRC', '', '2021-12-23', 'Study 1', '1'],
+            ['P1', 'D2', 'R4', 'Study2', 'Female', 'CRC', '', '2021-12-23', 'Study 2', '2'],
+            ['P1', '', 'R3', 'Study1', '', '', '', '2021-12-24', 'Study 1', '1'],
+            ['P1', '', 'R3', 'Study2', '', '', '', '2021-12-24', 'Study 2', '2'],
+        ], columns=['Subject Id', 'Diagnosis Id', 'Radiology Id', 'Study Id',
+                    'Gender', 'Diagnosis', 'Treatment', 'Radiology date', 'Study title', 'Individual study id'])
+        expected_df.set_index(['Subject Id', 'Diagnosis Id', 'Radiology Id', 'Study Id'], inplace=True)
+        pdt.assert_frame_equal(df, expected_df, check_dtype=False, check_categorical=False, check_like=True)
+
+
     def test_from_json_to_export_csr_df(self):
         csr_obs_path = os.path.join(os.path.dirname(__file__), 'csr_observations.json')
         input_json = json.loads(open(csr_obs_path).read())
@@ -304,7 +393,6 @@ class CsrTranformations(unittest.TestCase):
 
         self.assertIsNotNone(df)
         actual_ids = list(df.index.values)
-        df.to_csv('test_result.tsv', sep='\t')
         self.assertEqual(actual_ids, [
             ('P1', 'D1', 'BS1', 'BM1', 'R1', 'STUDY1'),
             ('P1', 'D10', 'BS10', 'BM15', '', 'STUDY1'),

--- a/tests/test_table_transformations.py
+++ b/tests/test_table_transformations.py
@@ -332,7 +332,7 @@ class CsrTranformations(unittest.TestCase):
         self.assertEqual(columns, [
             # patient
             '01. Date of birth',
-            '02. Gender',
+            '02. Sex',
             '01. Informed consent type',
             '03. Date informed consent withdrawn',
             '04. Informed consent material',


### PR DESCRIPTION
Added logic to include Radiology Id in a row key and radiology properties as columns (relates to https://github.com/thehyve/python_csr2transmart/pull/69). Expected results:

![Screenshot from 2021-12-17 14-33-49](https://user-images.githubusercontent.com/20908736/146552573-b8e984bf-f240-43e4-83c1-5bfc4196e4a1.png)

Based on the patient-to-subject renaming branch. Changes to properly handle properties of array type will follow.
