### PR TITLE
Fix docker image dependencies.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.9-slim
 
 ARG TRANSMART_PACKER_VERSION="0.6.0"
 


### PR DESCRIPTION
Otherwise, image build fails with:
"error: command 'gcc' failed: No such file or directory.
ERROR: Failed building wheel for hiredis"

Makes the image bigger, but this seems to be the best solution.